### PR TITLE
agent/unix: process netem duplicate value as probability

### DIFF
--- a/agents/unix/conf/tc/conf_qdisc_params.c
+++ b/agents/unix/conf/tc/conf_qdisc_params.c
@@ -250,8 +250,8 @@ static struct netem_param netem_params[] = {
         .name = "duplicate",
         .get = rtnl_netem_get_duplicate,
         .set = rtnl_netem_set_duplicate,
-        .val2str = default_val2str,
-        .str2val = default_str2val
+        .val2str = prob_val2str,
+        .str2val = prob_str2val
     },
     {
         .name = "duplicate_correlation",


### PR DESCRIPTION
On the TAPI side netem 'duplicate' handles as probability value, but on the agent side as number. From libnl point of view duplicate it is a probability as well.

Testing done:

Tested with [cns-virtblk-ts](https://github.com/Xilinx-CNS/cns-virtblk-ts) open source repo
Test name: [block-ts/blk-proxy/network_stimuli/fio_netem](https://github.com/Xilinx-CNS/cns-virtblk-ts/blob/main/block-ts/blk-proxy/network_stimuli/fio_netem.c)