### PR TITLE
lib/tapi_rpc: correcty output rpc_ioctl(PTP_SYS_OFFSET)

### DIFF
--- a/lib/tapi_rpc/ioctl.c
+++ b/lib/tapi_rpc/ioctl.c
@@ -1173,7 +1173,7 @@ rpc_ioctl(rcf_rpc_server *rpcs,
                  i < answ->n_samples * 2 + 1 && i < TE_ARRAY_LEN(answ->ts);
                  i++)
             {
-                te_string_append(req_str, "%s %lld.%06u, ",
+                te_string_append(req_str, "%s %lld.%09u, ",
                                  (i % 2 == 0 ? "sys" : "phc"),
                                  (long long int)(answ->ts[i].sec),
                                  (unsigned int)(answ->ts[i].nsec));


### PR DESCRIPTION
ioctl(PTP_SYS_OFFSET) returns samples of sys and phc timestamps each of which consists of seconds and nanoseconds. rpc_ioctl() prints them with dot between seconds and nanoseconds, but it adds leading zeros for nanoseconds only to 6 digits. It should be 9 digits instead.

Signed-off-by: Yurij Plotnikov <yurij.plotnikov@arknetworks.am>
Reviewed-by: Artemii Morozov <artemii.morozov@arknetworks.am>