### PR TITLE
agents/unix: add config nodes for amount of memory

### DIFF
--- a/doc/cm/cm_system.yml
+++ b/doc/cm/cm_system.yml
@@ -329,7 +329,7 @@
 
     - oid: "/agent/hardware/node/memory"
       access: read_only
-      type: int32
+      type: uint64
       d: |
          Amount of physical memory on a given node
          Name: none
@@ -345,7 +345,7 @@
 
     - oid: "/agent/hardware/node/memory/free"
       access: read_only
-      type: int32
+      type: uint64
       volatile: true
       d: |
          Free physical memory


### PR DESCRIPTION
Add /agent/hardware/node/memory and /agent/hardware/node/memory/free to configuration tree and add implementation of calculation of such values.

Signed-off-by: Boris Shleyfman <bshleyfman@oktet.co.il>
Reviewed-by: Yurij Plotnikov <yurij.plotnikov@arknetworks.am>