### PR TITLE
lib/tapi_rpc: add readlink support

### DIFF
--- a/lib/rpcserver/tarpc_imp.c
+++ b/lib/rpcserver/tarpc_imp.c
@@ -1881,6 +1881,27 @@ TARPC_FUNC(statvfs, {},
 )
 #endif /* HAVE_SYS_STATVFS_H */
 
+/*-------------- readlink() --------------------------------*/
+TARPC_FUNC(readlink, {},
+{
+    char *buf;
+
+    if (in->path == NULL || in->path[0] == '\0')
+    {
+        ERROR("Input path to readlink cannot be NULL or empty");
+        out->common._errno = TE_RC(TE_TA_UNIX, TE_EINVAL);
+        return;
+    }
+
+    buf = TE_ALLOC(in->bufsize);
+    if (buf == NULL)
+        TE_FATAL_ERROR("Failed to allocate readlink input buffer");
+
+    MAKE_CALL(out->retval = func(in->path, buf, in->bufsize));
+    out->resolved_path = buf;
+}
+)
+
 #ifdef HAVE_DIRENT_H
 /* struct_dirent_props */
 unsigned int

--- a/lib/rpcxdr/tarpc_base.x.m4
+++ b/lib/rpcxdr/tarpc_base.x.m4
@@ -795,6 +795,14 @@ struct tarpc_symlink_out {
     tarpc_int            retval;
 };
 
+/* readlink () */
+struct tarpc_readlink_in {
+    struct tarpc_in_arg common;
+
+    tarpc_size_t        bufsize;
+    string              path<>;
+};
+
 /* unlink() */
 struct tarpc_unlink_in {
     struct tarpc_in_arg common;
@@ -889,6 +897,13 @@ struct tarpc_statvfs_out {
 
     tarpc_int            retval;
     struct tarpc_statvfs buf;
+};
+
+struct tarpc_readlink_out {
+    struct tarpc_out_arg common;
+
+    string              resolved_path<>;
+    tarpc_ssize_t       retval;
 };
 
 /* struct_dirent_props() */
@@ -5567,6 +5582,7 @@ program tarpc
 
         RPC_DEF(link)
         RPC_DEF(symlink)
+        RPC_DEF(readlink)
         RPC_DEF(unlink)
         RPC_DEF(rename)
         RPC_DEF(mkdir)

--- a/lib/tapi_rpc/tapi_rpc_unistd.h
+++ b/lib/tapi_rpc/tapi_rpc_unistd.h
@@ -1364,6 +1364,18 @@ extern int rpc_symlink(rcf_rpc_server *rpcs,
                        const char *path1, const char *path2);
 
 /**
+ * Resolve a symbolic link.
+ *
+ * @param rpcs      RPC server handle.
+ * @param path      Path to symbolic link.
+ * @param buf       Buffer for the resolved link.
+ * @param bufsize   Length of the buffer.
+ *
+ * @return Number of bytes put in the buffer.
+ */
+extern ssize_t rpc_readlink(rcf_rpc_server *rpcs, const char *path, char *buf,
+                            size_t bufsize);
+/**
  * Remove a directory entry.
  *
  * @param rpcs      RPC server

--- a/lib/tapi_rpc/unistd.c
+++ b/lib/tapi_rpc/unistd.c
@@ -2980,6 +2980,32 @@ rpc_symlink(rcf_rpc_server *rpcs,
     RETVAL_INT(symlink, out.retval);
 }
 
+ssize_t
+rpc_readlink(rcf_rpc_server *rpcs, const char *path, char *buf, size_t bufsize)
+{
+    tarpc_readlink_in  in;
+    tarpc_readlink_out out;
+
+    memset(&in, 0, sizeof(in));
+    memset(&out, 0, sizeof(out));
+
+    in.bufsize = bufsize;
+    in.path = strdup(path);
+
+    rcf_rpc_call(rpcs, "readlink", &in, &out);
+    free(in.path);
+    CHECK_RETVAL_VAR_IS_GTE_MINUS_ONE(readlink, out.retval);
+
+    TAPI_RPC_LOG(rpcs, readlink, "%s, %zu", "%s, %d", path, bufsize,
+                 out.resolved_path, out.retval);
+
+    if (out.retval >= 0)
+        te_strlcpy(buf, out.resolved_path, bufsize);
+
+    TAPI_RPC_OUT(readlink, out.retval < 0);
+    return out.retval;
+}
+
 int
 rpc_unlink(rcf_rpc_server *rpcs, const char *path)
 {


### PR DESCRIPTION
This function is required to determine, for example, a network interface's BDF given its name.
To do that, a symlink in sysfs has to be read.

Tested with a pending patch to net-drv-ts. This functionality is required there to determine the debug paths in sysfs.