### PR TITLE
doc/cm: reflect PCI serial number dependency on driver

### DIFF
--- a/doc/cm/cm_pci.yml
+++ b/doc/cm/cm_pci.yml
@@ -245,6 +245,8 @@
     - oid: "/agent/hardware/pci/device/serialno"
       access: read_only
       type: string
+      depends:
+        - oid: "/agent/hardware/pci/device/driver"
       d: |
          PCIe device serial number. Note that this is not the same as
          /agent/hardware/pci/device/vpd:SN,


### PR DESCRIPTION
Prevent Configurator from trying to restore PCI serial numbers of devices that were rebound to a different driver during test execution.

PCI serial numbers are extracted using the devlink interface, which is not available with every driver. For example, when vfio-pci is used, a blank serial number is reported by the Configurator.

By restoring the driver first, the Configurator reverses the change to the serial number instance implicitly, thus avoiding the need to restore it explicitly.

Testing done:
Cleanup after DPDK-based vswitch-ts configurations no longer fails trying to perform an invalid `set` operation