### PR TITLE
23 01 17 remove xml from configurator

### DIFF
--- a/doc/cm/cm_radius.yml
+++ b/doc/cm/cm_radius.yml
@@ -82,7 +82,7 @@
       type: string
       d: |
          A set of attributes that should be included into
-        Access-Challenge RADIUS message sent to this user.
+         Access-Challenge RADIUS message sent to this user.
          Name: empty
          Value: a list of attributes in format:
                 [AttributeName=Value[,AttributeName=Value]*]

--- a/engine/configurator/conf_backup.h
+++ b/engine/configurator/conf_backup.h
@@ -11,15 +11,17 @@
 #define __TE_CONF_BACKUP_H__
 
 #include "te_vector.h"
+#include "conf_cyaml.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * Process "backup" configuration file or backup file.
+ * Process backup structure obtained from "backup" configuration file
+ * or backup file.
  *
- * @param node     `<backup>` node pointer
+ * @param backup   the backup structure
  * @param restore  if TRUE, the configuration should be restored after
  *                 unsuccessful dynamic history restoring
  * @param subtrees Vector of the subtrees to restore. May be @c NULL for
@@ -27,8 +29,9 @@ extern "C" {
  *
  * @return status code (errno.h)
  */
-extern int cfg_backup_process_file(xmlNodePtr node, te_bool restore,
-                                   const te_vec *subtrees);
+extern te_errno cfg_backup_process_structure(backup_seq *backup,
+                                             te_bool restore,
+                                             const te_vec *subtrees);
 
 /**
  * Save current version of the TA subtree,
@@ -41,27 +44,17 @@ extern int cfg_backup_process_file(xmlNodePtr node, te_bool restore,
 extern int cfg_backup_restore_ta(char *ta);
 
 /**
- * Create "backup" configuration file with specified name.
+ * Create "backup" cyaml struture and then serialize it configuration file
+ * with specified name.
  *
- * @param filename   name of the file to be created
- * @param subtrees   Vector of the subtrees to create a backup file.
- *                   @c NULL to create backup fo all the subtrees
+ * @param filename      name of the file to be created
+ * @param subtrees      vector of the subtrees to create a backup file
+ *                      @c NULL to create backup fo all the subtrees
  *
  * @return status code (errno.h)
  */
-extern int cfg_backup_create_file(const char *filename,
-                                  const te_vec *subtrees);
-
-/**
- * Create file XML file with subtrees to filter backup file
- *
- * @param filename Name of the filter file
- * @param subtrees Vector of the subtrees
- *
- * @return Status code
- */
-extern te_errno cfg_backup_create_filter_file(const char *filename,
-                                              const te_vec *subtrees);
+extern te_errno cfg_backup_create_file(const char *filename,
+                                       const te_vec *subtrees);
 
 /**
  * Verify backup configuration file

--- a/engine/configurator/conf_cyaml.c
+++ b/engine/configurator/conf_cyaml.c
@@ -1,0 +1,842 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <cyaml/cyaml.h>
+#include "conf_cyaml.h"
+
+/*
+ ******************************************************************************
+ * CYAML schema to tell libcyaml about both expected YAML and data structure.
+ *
+ * (Our CYAML schema is just a bunch of static const data.)
+ ******************************************************************************
+ */
+
+/** Enumeration for object or instance. It answers if it is an object */
+enum cfg_cyaml_scope {
+    CFG_CYAML_INSTANCE = 0, /* It is a default value */
+    CFG_CYAML_OBJECT
+};
+
+/** Mapping from instance or object strings to enum values for schema. */
+static const cyaml_strval_t cyaml_scope_strings[] = {
+    {"object",   CFG_CYAML_OBJECT},
+    {"instance", CFG_CYAML_INSTANCE},
+};
+
+/** Mapping from @c access strings to enum values for schema. */
+static const cyaml_strval_t cyaml_access_strings[] = {
+    {"read_write",  CFG_READ_WRITE },
+    {"read_only",   CFG_READ_ONLY  },
+    {"read_create", CFG_READ_CREATE},
+};
+
+/** Mapping from @c type strings to flag enum for schema. */
+static const cyaml_strval_t cyaml_type_strings[] = {
+    {"none",    CVT_NONE},
+    {"bool",    CVT_BOOL},
+    {"int8",    CVT_INT8},
+    {"uint8",   CVT_UINT8},
+    {"int16",   CVT_INT16},
+    {"uint16",  CVT_UINT16},
+    {"int32",   CVT_INT32},
+    {"integer", CVT_INT32},
+    {"uint32",  CVT_UINT32},
+    {"int64",   CVT_INT64},
+    {"uint64",  CVT_UINT64},
+    {"string",  CVT_STRING},
+    {"address", CVT_ADDRESS},
+};
+
+/** Mapping from @c no_parent_dep strings to enum values for schema. */
+static const cyaml_strval_t cyaml_no_parent_dep_strings[] = {
+    {"yes", FALSE}, /* it is a default value */
+    {"no",  TRUE},
+};
+
+/**
+ * The depends mapping's field definitions schema is an array.
+ *
+ * All the field entries will refer to their parent mapping's structure,
+ * in this case, @c depends_entry.
+ */
+static const cyaml_schema_field_t cyaml_depends_entry_fields_schema[] = {
+    /**
+     * The first field in the mapping is an oid.
+     *
+     * YAML key: @c oid.
+     * C structure member for this key: @c oid.
+     *
+     * Its CYAML type is string pointer, and we have no minimum or maximum
+     * string length constraints.
+     */
+    CYAML_FIELD_STRING_PTR("oid", CYAML_FLAG_POINTER,
+                           depends_entry, oid, 0, CYAML_UNLIMITED),
+
+    /**
+     * The scope field is an enum.
+     *
+     * YAML key: @c scope.
+     * C structure member for this key: @c scope.
+     * Array mapping strings to values: cyaml_scope_strings
+     *
+     * Its CYAML type is ENUM, so an array of cyaml_strval_t must be
+     * provided to map from string to values.
+     */
+    CYAML_FIELD_ENUM("scope", CYAML_FLAG_DEFAULT | CYAML_FLAG_OPTIONAL,
+                     depends_entry, scope, cyaml_scope_strings,
+                     CYAML_ARRAY_LEN(cyaml_scope_strings)),
+
+    CYAML_FIELD_END
+};
+
+/**
+ * The value for a depends is a mapping.
+ *
+ * Its fields are defined in @c depends_entries_fields_schema.
+ */
+static const cyaml_schema_value_t cyaml_depends_schema = {
+        CYAML_VALUE_MAPPING(CYAML_FLAG_DEFAULT, depends_entry,
+                            cyaml_depends_entry_fields_schema),
+};
+
+/**
+ * The object mapping's field definitions schema is an array.
+ *
+ * All the field entries will refer to their parent mapping's structure,
+ * in this case, @c object_type.
+ */
+static const cyaml_schema_field_t cyaml_object_fields_schema[] = {
+    /**
+     * The first field in the mapping is oid.
+     *
+     * YAML key: @c oid.
+     * C structure member for this key: @c oid.
+     *
+     * Its CYAML type is string pointer, and we have no minimum or maximum
+     * string length constraints.
+     */
+    CYAML_FIELD_STRING_PTR("oid", CYAML_FLAG_POINTER,
+                           object_type, oid, 0, CYAML_UNLIMITED),
+
+    /**
+     * The access field is an enum.
+     *
+     * YAML key: @c access.
+     * C structure member for this key: @c access.
+     * Array mapping strings to values: cyaml_access_strings
+     *
+     * Its CYAML type is ENUM, so an array of cyaml_strval_t must be
+     * provided to map from string to values.
+     */
+    CYAML_FIELD_ENUM("access", CYAML_FLAG_DEFAULT,
+                     object_type, access, cyaml_access_strings,
+                     CYAML_ARRAY_LEN(cyaml_access_strings)),
+
+    /**
+     * The type field is an enum.
+     *
+     * YAML key: @c type.
+     * C structure member for this key: @c type.
+     * Array mapping strings to values: cyaml_type_strings
+     *
+     * Its CYAML type is ENUM, so an array of cyaml_strval_t must be
+     * provided to map from string to values.
+     */
+    CYAML_FIELD_ENUM("type", CYAML_FLAG_DEFAULT | CYAML_FLAG_OPTIONAL,
+                     object_type, type, cyaml_type_strings,
+                     CYAML_ARRAY_LEN(cyaml_type_strings)),
+
+    /**
+     * The unit field is a te_bool.
+     *
+     * YAML key: @c unit.
+     * C structure member for this key: @c unit.
+     */
+    CYAML_FIELD_BOOL("unit", CYAML_FLAG_DEFAULT | CYAML_FLAG_OPTIONAL,
+                     object_type, unit),
+
+    /**
+     * The default field in the mapping is a string.
+     *
+     * YAML key: @c default.
+     * C structure member for this key: @c def_val.
+     *
+     * Its CYAML type is string pointer, and we have no minimum or maximum
+     * string length constraints.
+     */
+    CYAML_FIELD_STRING_PTR("default", CYAML_FLAG_POINTER | CYAML_FLAG_OPTIONAL,
+                           object_type, def_val, 0, CYAML_UNLIMITED),
+
+    /**
+     * The volat field is a te_bool.
+     *
+     * YAML key: @volatile.
+     * C structure member for this key: @c volat.
+     */
+    CYAML_FIELD_BOOL("volatile", CYAML_FLAG_DEFAULT | CYAML_FLAG_OPTIONAL,
+                     object_type, volat),
+
+    /**
+     * The substitution field is a te_bool.
+     *
+     * YAML key: @c substitution.
+     * C structure member for this key: @c substitution.
+     */
+    CYAML_FIELD_BOOL("substitution", CYAML_FLAG_DEFAULT | CYAML_FLAG_OPTIONAL,
+                     object_type, substitution),
+
+    /**
+     * The parent-dep field is a te_bool but we pretend that it is a enum.
+     *
+     * YAML key: @c parent-dep.
+     * C structure member for this key: @c no_parent_dep.
+     *
+     * Array mapping strings to values: @cyaml_no_parent_dep_strings
+     *
+     * Its CYAML type is ENUM, so an array of @cyaml_strval_t must be
+     * provided to map from string to values.
+     */
+    CYAML_FIELD_ENUM("parent-dep", CYAML_FLAG_DEFAULT | CYAML_FLAG_OPTIONAL,
+                     object_type, no_parent_dep, cyaml_no_parent_dep_strings,
+                     CYAML_ARRAY_LEN(cyaml_no_parent_dep_strings)),
+
+    /**
+     * The next field is the instances or objects that this object depends on.
+     *
+     * YAML key: @c depends.
+     * C structure member for this key: @c depends.
+     *
+     * Its CYAML type is a sequence.
+     *
+     * Since it's a sequence type, the value schema for its entries must
+     * be provided too.  In this case, it's cyaml_depends_schema.
+     *
+     * Since it's not a sequence of a fixed-length, we must tell CYAML
+     * where the sequence entry count is to be stored.  In this case, it
+     * goes in the @c depends_count C structure member in
+     * @c object_type.
+     * Since this is @c depends with the @c _count postfix, we can use
+     * the following macro, which assumes a postfix of @c _count in the
+     * struct member name.
+     */
+    CYAML_FIELD_SEQUENCE("depends",
+                         CYAML_FLAG_POINTER | CYAML_FLAG_OPTIONAL,
+                         object_type, depends,
+                         &cyaml_depends_schema, 0, CYAML_UNLIMITED),
+
+    /**
+     * If the YAML contains a field that our program is not interested in
+     * we can ignore it, so the value of the field will not be loaded.
+     *
+     * Note that unless the OPTIONAL flag is set, the ignored field must
+     * be present.
+     *
+     * Another way of handling this would be to use the config flag
+     * to ignore unknown keys.  This config is passed to libcyaml
+     * separately from the schema.
+     */
+    CYAML_FIELD_IGNORE("d", CYAML_FLAG_OPTIONAL),
+
+    CYAML_FIELD_END
+};
+
+/**
+ * The instance mapping's field definitions schema is an array.
+ *
+ * All the field entries will refer to their parent mapping's structure.
+ */
+static const cyaml_schema_field_t cyaml_instance_fields_schema[] = {
+    /**
+     * The first field in the mapping is oid.
+     *
+     * YAML key: @c oid.
+     * C structure member for this key: @c oid.
+     *
+     * Its CYAML type is string pointer, and we have no minimum or maximum
+     * string length constraints.
+     */
+    CYAML_FIELD_STRING_PTR("oid", CYAML_FLAG_POINTER,
+                           instance_type, oid, 0, CYAML_UNLIMITED),
+
+    /**
+     * The value field in the mapping is a string.
+     *
+     * YAML key: @c value.
+     * C structure member for this key: @c value.
+     *
+     * Its CYAML type is string pointer, and we have no minimum or maximum
+     * string length constraints.
+     */
+    CYAML_FIELD_STRING_PTR("value", CYAML_FLAG_POINTER | CYAML_FLAG_OPTIONAL,
+                           instance_type, value, 0, CYAML_UNLIMITED),
+
+    CYAML_FIELD_END
+};
+
+/**
+ * The backup_entry mapping's field definitions schema is an array.
+ *
+ * All the field entries will refer to their parent mapping's structure,
+ * in this case, @c backup_entry.
+ */
+static const cyaml_schema_field_t cyaml_backup_entry_fields_schema[] = {
+    /**
+     * The first field is the object.
+     *
+     * YAML key: @c object.
+     * C structure member for this key: @c object.
+     *
+     * Its CYAML type is a mapping.
+     *
+     * Since it's a mapping type, the schema for its mapping's fields must
+     * be provided too. In this case, it's cyaml_object_fields_schema.
+     */
+    CYAML_FIELD_MAPPING_PTR("object", CYAML_FLAG_POINTER | CYAML_FLAG_OPTIONAL,
+                            backup_entry, object, cyaml_object_fields_schema),
+
+    /**
+     * The next field is the instance.
+     *
+     * YAML key: @c instance.
+     * C structure member for this key: @c instance.
+     *
+     * Its CYAML type is a mapping.
+     *
+     * Since it's a mapping type, the schema for its mapping's fields must
+     * be provided too. In this case, it's cyaml_instance_fields_schema.
+     */
+    CYAML_FIELD_MAPPING_PTR("instance",
+                            CYAML_FLAG_POINTER | CYAML_FLAG_OPTIONAL,
+                            backup_entry, instance,
+                            cyaml_instance_fields_schema),
+
+    CYAML_FIELD_END
+};
+
+/**
+ * The value for a backup_entry is a mapping.
+ *
+ * Its fields are defined in cyaml_backup_entry_fields_schema.
+ */
+static const cyaml_schema_value_t cyaml_backup_entry_schema = {
+    CYAML_VALUE_MAPPING(CYAML_FLAG_DEFAULT, backup_entry,
+                        cyaml_backup_entry_fields_schema),
+};
+
+/**
+ * The backup mapping's field definitions schema is an array.
+ *
+ * All the field entries will refer to their parent mapping's structure,
+ * in this case, @c backup_seq.
+ */
+static const cyaml_schema_field_t cyaml_backup_fields_schema[] = {
+    /**
+     * The only field is the instances or objects.
+     *
+     * YAML key: @c backup.
+     * C structure member for this key: @c entries.
+     *
+     * Its CYAML type is a sequence.
+     *
+     * Since it's a sequence type, the value schema for its entries must
+     * be provided too. In this case, it's cyaml_backup_entry_schema.
+     *
+     * Since it's not a sequence of a fixed-length, we must tell CYAML
+     * where the sequence entry count is to be stored. In this case, it
+     * goes in the @c entries_count C structure member in
+     * @c backup_seq.
+     * Since this is @c entries with the @c _count postfix, we can use
+     * the following macro, which assumes a postfix of @c _count in the
+     * struct member name.
+     */
+    CYAML_FIELD_SEQUENCE("backup",
+                         CYAML_FLAG_POINTER | CYAML_FLAG_OPTIONAL,
+                         backup_seq, entries,
+                         &cyaml_backup_entry_schema, 0, CYAML_UNLIMITED),
+
+    CYAML_FIELD_END
+};
+
+/**
+ * Top-level schema of the backup. The top level value for the backup is
+ * a sequence.
+ *
+ * Its fields are defined in cyaml_backup_entry_fields_schema.
+ */
+static const cyaml_schema_value_t cyaml_backup_schema = {
+    CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER, backup_seq,
+                        cyaml_backup_fields_schema),
+};
+
+/**
+ * The schema of object. Its value is a mapping.
+ *
+ * Its fields are defined in cyaml_object_fields_schema.
+ */
+static const cyaml_schema_value_t cyaml_object_schema = {
+    CYAML_VALUE_MAPPING(CYAML_FLAG_DEFAULT, object_type,
+                        cyaml_object_fields_schema),
+};
+
+/**
+ * The schema of instance. Its value is a mapping.
+ *
+ * Its fields are defined in cyaml_instance_fields_schema.
+ */
+static const cyaml_schema_value_t cyaml_instance_schema = {
+    CYAML_VALUE_MAPPING(CYAML_FLAG_DEFAULT, instance_type,
+                        cyaml_instance_fields_schema),
+};
+
+/**
+ * The history_entry mapping's field definitions schema is an array.
+ *
+ * All the field entries will refer to their parent mapping's structure,
+ * in this case, @c history_entry.
+ */
+static const cyaml_schema_field_t cyaml_history_entry_fields_schema[] = {
+    /**
+     * The first field is the register.
+     *
+     * YAML key: @c register.
+     * C structure member for this key: @c reg.
+     *
+     * Its CYAML type is a sequence.
+     *
+     * Since it's a sequence type, the value schema for its entries must
+     * be provided too.  In this case, it's cyaml_object_schema.
+     *
+     * Since it's not a sequence of a fixed-length, we must tell CYAML
+     * where the sequence entry count is to be stored.  In this case, it
+     * goes in the @c reg_count C structure member in
+     * @c history_entry.
+     * Since this is @c reg with the @c _count postfix, we can use
+     * the following macro, which assumes a postfix of @c _count in the
+     * struct member name.
+     */
+    CYAML_FIELD_SEQUENCE("register",
+                         CYAML_FLAG_POINTER | CYAML_FLAG_OPTIONAL,
+                         history_entry, reg,
+                         &cyaml_object_schema, 0, CYAML_UNLIMITED),
+
+    /**
+     * The next field is the unregister.
+     *
+     * YAML key: @c unregister.
+     * C structure member for this key: @c unreg.
+     *
+     * Its CYAML type is a sequence.
+     *
+     * Since it's a sequence type, the value schema for its entries must
+     * be provided too.  In this case, it's cyaml_object_schema.
+     *
+     * Since it's not a sequence of a fixed-length, we must tell CYAML
+     * where the sequence entry count is to be stored.  In this case, it
+     * goes in the @c unreg_count C structure member in
+     * @c history_entry.
+     * Since this is @c unreg with the @c _count postfix, we can use
+     * the following macro, which assumes a postfix of @c _count in the
+     * struct member name.
+     */
+    CYAML_FIELD_SEQUENCE("unregister",
+                         CYAML_FLAG_POINTER | CYAML_FLAG_OPTIONAL,
+                         history_entry, unreg,
+                         &cyaml_object_schema, 0, CYAML_UNLIMITED),
+
+    /**
+     * The next field is the add.
+     *
+     * YAML key: @c add.
+     * C structure member for this key: @c add.
+     *
+     * Its CYAML type is a sequence.
+     *
+     * Since it's a sequence type, the value schema for its entries must
+     * be provided too. In this case, it's cyaml_instance_schema.
+     *
+     * Since it's not a sequence of a fixed-length, we must tell CYAML
+     * where the sequence entry count is to be stored. In this case, it
+     * goes in the @c add_count C structure member in
+     * @c history_entry.
+     * Since this is @c add with the @c _count postfix, we can use
+     * the following macro, which assumes a postfix of @c _count in the
+     * struct member name.
+     */
+    CYAML_FIELD_SEQUENCE("add",
+                         CYAML_FLAG_POINTER | CYAML_FLAG_OPTIONAL,
+                         history_entry, add,
+                         &cyaml_instance_schema, 0, CYAML_UNLIMITED),
+
+    /**
+     * The next field is the get.
+     *
+     * YAML key: @c get.
+     * C structure member for this key: @c get.
+     *
+     * Its CYAML type is a sequence.
+     *
+     * Since it's a sequence type, the value schema for its entries must
+     * be provided too. In this case, it's cyaml_instance_schema.
+     *
+     * Since it's not a sequence of a fixed-length, we must tell CYAML
+     * where the sequence entry count is to be stored. In this case, it
+     * goes in the @c get_count C structure member in
+     * @c history_entry.
+     * Since this is @c get with the @c _count postfix, we can use
+     * the following macro, which assumes a postfix of @c _count in the
+     * struct member name.
+     */
+    CYAML_FIELD_SEQUENCE("get",
+                         CYAML_FLAG_POINTER | CYAML_FLAG_OPTIONAL,
+                         history_entry, get,
+                         &cyaml_instance_schema, 0, CYAML_UNLIMITED),
+
+    /**
+     * The next field is the delete.
+     *
+     * YAML key: @c delete.
+     * C structure member for this key: @c delete.
+     *
+     * Its CYAML type is a sequence.
+     *
+     * Since it's a sequence type, the value schema for its entries must
+     * be provided too. In this case, it's cyaml_instance_schema.
+     *
+     * Since it's not a sequence of a fixed-length, we must tell CYAML
+     * where the sequence entry count is to be stored. In this case, it
+     * goes in the @c delete_count C structure member in
+     * @c history_entry.
+     * Since this is @c delete with the @c _count postfix, we can use
+     * the following macro, which assumes a postfix of @c _count in the
+     * struct member name.
+     */
+    CYAML_FIELD_SEQUENCE("delete",
+                         CYAML_FLAG_POINTER | CYAML_FLAG_OPTIONAL,
+                         history_entry, delete,
+                         &cyaml_instance_schema, 0, CYAML_UNLIMITED),
+
+    /**
+     * The next field is the copy.
+     *
+     * YAML key: @c copy.
+     * C structure member for this key: @c copy.
+     *
+     * Its CYAML type is a sequence.
+     *
+     * Since it's a sequence type, the value schema for its entries must
+     * be provided too. In this case, it's cyaml_instance_schema.
+     *
+     * Since it's not a sequence of a fixed-length, we must tell CYAML
+     * where the sequence entry count is to be stored. In this case, it
+     * goes in the @c copy_count C structure member in
+     * @c history_entry.
+     * Since this is @c copy with the @c _count postfix, we can use
+     * the following macro, which assumes a postfix of @c _count in the
+     * struct member name.
+     */
+    CYAML_FIELD_SEQUENCE("copy",
+                         CYAML_FLAG_POINTER | CYAML_FLAG_OPTIONAL,
+                         history_entry, copy,
+                         &cyaml_instance_schema, 0, CYAML_UNLIMITED),
+
+    /**
+     * The next field is the set.
+     *
+     * YAML key: @c set.
+     * C structure member for this key: @c set.
+     *
+     * Its CYAML type is a sequence.
+     *
+     * Since it's a sequence type, the value schema for its entries must
+     * be provided too. In this case, it's cyaml_instance_schema.
+     *
+     * Since it's not a sequence of a fixed-length, we must tell CYAML
+     * where the sequence entry count is to be stored. In this case, it
+     * goes in the @c set_count C structure member in
+     * @c history_entry.
+     * Since this is @c set with the @c _count postfix, we can use
+     * the following macro, which assumes a postfix of @c _count in the
+     * struct member name.
+     */
+    CYAML_FIELD_SEQUENCE("set",
+                         CYAML_FLAG_POINTER | CYAML_FLAG_OPTIONAL,
+                         history_entry, set,
+                         &cyaml_instance_schema, 0, CYAML_UNLIMITED),
+
+    /**
+     * If the YAML contains a field that our program is not interested in
+     * we can ignore it, so the value of the field will not be loaded.
+     *
+     * Note that unless the OPTIONAL flag is set, the ignored field must
+     * be present.
+     *
+     * Another way of handling this would be to use the config flag
+     * to ignore unknown keys.  This config is passed to libcyaml
+     * separately from the schema.
+     */
+    CYAML_FIELD_IGNORE("comment", CYAML_FLAG_OPTIONAL),
+
+    /**
+     * The reboot_ta in the mapping is a string.
+     *
+     * YAML key: @c reboot_ta.
+     * C structure member for this key: @c reboot_ta.
+     *
+     * Its CYAML type is string pointer, and we have no minimum or maximum
+     * string length constraints.
+     */
+    CYAML_FIELD_STRING_PTR("reboot_ta",
+                           CYAML_FLAG_POINTER | CYAML_FLAG_OPTIONAL,
+                           history_entry, reboot_ta, 0, CYAML_UNLIMITED),
+
+    CYAML_FIELD_END
+};
+
+/**
+ * The value for a @c history_entry is a mapping.
+ *
+ * Its fields are defined in cyaml_history_entry_fields_schema.
+ */
+static const cyaml_schema_value_t cyaml_history_entry_schema = {
+    CYAML_VALUE_MAPPING(CYAML_FLAG_DEFAULT,
+                        history_entry,
+                        cyaml_history_entry_fields_schema),
+};
+
+/**
+ * The history field definitions schema is an array.
+ *
+ * All the field entries will refer to their parent mapping's structure,
+ * in this case, @c history_seq.
+ */
+static const cyaml_schema_field_t cyaml_history_fields_schema[] = {
+    /**
+     * The only field is the register, unregister, add or something.
+     *
+     * YAML key: @c history.
+     * C structure member for this key: @c entries.
+     *
+     * Its CYAML type is a sequence.
+     *
+     * Since it's a sequence type, the value schema for its entries must
+     * be provided too. In this case, it's cyaml_history_entry_schema.
+     *
+     * Since it's not a sequence of a fixed-length, we must tell CYAML
+     * where the sequence entry count is to be stored. In this case, it
+     * goes in the @c entries_count C structure member in
+     * @c history_seq.
+     * Since this is @c entries with the @c _count postfix, we can use
+     * the following macro, which assumes a postfix of @c _count in the
+     * struct member name.
+     */
+    CYAML_FIELD_SEQUENCE("history",
+                         CYAML_FLAG_POINTER | CYAML_FLAG_OPTIONAL,
+                         history_seq, entries,
+                         &cyaml_history_entry_schema, 0, CYAML_UNLIMITED),
+
+    CYAML_FIELD_END
+};
+
+/**
+ * Top-level schema of the history. The top level value for the history is
+ * a sequence.
+ *
+ * Its fields are defined in cyaml_history_entry_fields_schema.
+ */
+static const cyaml_schema_value_t cyaml_history_schema = {
+    CYAML_VALUE_MAPPING(CYAML_FLAG_POINTER,
+                        history_seq, cyaml_history_fields_schema),
+};
+
+
+/*
+ ******************************************************************************
+ * Actual code to load and save YAML doc using libcyaml.
+ ******************************************************************************
+ */
+/**
+ * Our CYAML config.
+ *
+ * If you don't want to change it between calls, make it const.
+ *
+ * Here we have a very basic config.
+ */
+cyaml_config_t cyaml_config = {
+    .log_fn = cyaml_log,            /** Use the default logging function. */
+    .mem_fn = cyaml_mem,            /** Use the default memory allocator. */
+    .log_level = CYAML_LOG_WARNING, /** Logging errors and warnings only. */
+    /*  .log_level = CYAML_LOG_DEBUG,   for logging debug. */
+};
+
+te_errno
+cyaml_err2te_errno(cyaml_err_t err)
+{
+    switch (err)
+    {
+        /* Success. */
+        case CYAML_OK:
+            return 0;
+
+        /* Memory allocation failed. */
+        case CYAML_ERR_OOM:
+            ERROR("There is a CYAML error %s(%d)", cyaml_strerror(err), err);
+            TE_FATAL_ERROR("Out of memory");
+
+        default:
+        {
+            ERROR("There is a CYAML error %s(%d)", cyaml_strerror(err), err);
+            return TE_EINVAL;
+        }
+    }
+}
+
+void
+cfg_yaml_free_backup_seq(backup_seq *backup)
+{
+    cyaml_free(&cyaml_config, &cyaml_backup_schema, backup, 0);
+}
+
+void
+cfg_yaml_free_obj(object_type *obj)
+{
+    unsigned int i;
+
+    free(obj->d);
+    free(obj->oid);
+    free(obj->def_val);
+    for (i = 0; i < obj->depends_count; i++)
+        free(obj->depends[i].oid);
+    free(obj->depends);
+}
+
+void
+cfg_yaml_free_inst(instance_type *inst)
+{
+    free(inst->if_cond);
+    free(inst->oid);
+    free(inst->value);
+}
+
+void
+cfg_yaml_free_b_entry(backup_entry *entry)
+{
+    if (entry->object != NULL)
+    {
+        cfg_yaml_free_obj(entry->object);
+        free(entry->object);
+    }
+
+    if (entry->instance != NULL)
+    {
+        cfg_yaml_free_inst(entry->instance);
+        free(entry->instance);
+    }
+}
+
+void
+cfg_yaml_free_b_seq(backup_seq *b_seq)
+{
+    unsigned int i;
+
+    for (i = 0; i < b_seq->entries_count; i++)
+        cfg_yaml_free_b_entry(&b_seq->entries[i]);
+    free(b_seq->entries);
+    b_seq->entries = NULL;
+    b_seq->entries_count = 0;
+}
+
+void
+cfg_yaml_free_cond_entry(cond_entry *cond)
+{
+    free(cond->if_cond);
+    if (cond->then_cond != NULL)
+    {
+        cfg_yaml_free_hist_seq(cond->then_cond);
+        free(cond->then_cond);
+    }
+    if (cond->else_cond != NULL)
+    {
+        cfg_yaml_free_hist_seq(cond->else_cond);
+        free(cond->else_cond);
+    }
+}
+
+void
+cfg_yaml_free_hist_entry(history_entry *entry)
+{
+    unsigned int i;
+
+    free(entry->comment);
+
+    if (entry->cond != NULL)
+    {
+        cfg_yaml_free_cond_entry(entry->cond);
+        free(entry->cond);
+    }
+
+    free(entry->reboot_ta);
+
+#define FREE_SEQUENCE(cmd_, free_func_) \
+    do {                                               \
+        for (i = 0; i < entry->cmd_ ## _count; i++)    \
+            free_func_(&entry->cmd_[i]);               \
+        free(entry->cmd_);                             \
+        entry->cmd_ = NULL;                            \
+        entry->cmd_ ## _count = 0;                     \
+    }                                                  \
+    while (0)
+
+    FREE_SEQUENCE(incl, free);
+    FREE_SEQUENCE(reg, cfg_yaml_free_obj);
+    FREE_SEQUENCE(unreg, cfg_yaml_free_obj);
+    FREE_SEQUENCE(add, cfg_yaml_free_inst);
+    FREE_SEQUENCE(get, cfg_yaml_free_inst);
+    FREE_SEQUENCE(delete, cfg_yaml_free_inst);
+    FREE_SEQUENCE(copy, cfg_yaml_free_inst);
+    FREE_SEQUENCE(set, cfg_yaml_free_inst);
+
+#undef FREE_SEQUENCE
+}
+
+void
+cfg_yaml_free_hist_seq(history_seq *hist_seq)
+{
+    unsigned int i;
+
+    for (i = 0; i < hist_seq->entries_count; i++)
+        cfg_yaml_free_hist_entry(&hist_seq->entries[i]);
+    free(hist_seq->entries);
+    hist_seq->entries = NULL;
+    hist_seq->entries_count = 0;
+}
+
+te_errno
+cfg_yaml_save_backup_file(const char *filename, backup_seq *backup)
+{
+    cyaml_err_t err;
+
+    err = cyaml_save_file(filename, &cyaml_config,
+                          &cyaml_backup_schema, backup, 0);
+    return cyaml_err2te_errno(err);
+}
+
+te_errno
+cfg_yaml_parse_backup_file(const char *filename, backup_seq **backup)
+{
+    cyaml_err_t err;
+
+    err = cyaml_load_file(filename, &cyaml_config,
+                          &cyaml_history_schema, (cyaml_data_t **) backup, NULL);
+    return cyaml_err2te_errno(err);
+}
+
+te_errno
+cfg_yaml_save_history_file(const char *filename, history_seq *history)
+{
+    cyaml_err_t err;
+
+    err = cyaml_save_file(filename, &cyaml_config,
+                          &cyaml_history_schema, history, 0);
+    return cyaml_err2te_errno(err);
+}

--- a/engine/configurator/conf_cyaml.h
+++ b/engine/configurator/conf_cyaml.h
@@ -1,0 +1,272 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/** @file
+ * @brief YAML configuration types and schema
+ *
+ * API definitions.
+ *
+ * Copyright (C) 2018-2022 OKTET Labs Ltd. All rights reserved.
+ */
+
+#ifndef __TE_CONF_CYAML_H__
+#define __TE_CONF_CYAML_H__
+
+#include "conf_api.h"
+#include "conf_types.h"
+#include "logger_api.h"
+
+/*
+ ******************************************************************************
+ * C data structure for storing a backup.
+ *
+ * This is what we want to load the YAML into.
+ ******************************************************************************
+ */
+
+/** Structure for storing depends entry */
+typedef struct depends_entry {
+    /** @c oid is taken from YAML key @c oid in depends entry */
+    char *oid;
+    /**
+     * @c scope is taken from YAML key @c scope in depends entry
+     * optional; 0 is default value means instance
+     */
+    uint8_t scope;
+} depends_entry;
+
+/**
+ * Structure for storing object information. The name for the field coincides
+ * with the corresponding YAML key except @ def_val for @c default,
+ * @c volat for @c volatile and @ no_parent_dep for @c parent_dep. In the last
+ * case there is also a logical negation.
+ */
+typedef struct object_type {
+    /**
+     * @c d is taken from YAML key @c d in object.
+     * @c d means description and will be ignored.
+     * CYAML doesn'know about this field.
+     */
+    char *d;
+
+    /** @c oid is taken from YAML key @c oid in object */
+    char *oid;
+    /** @ access is taken from YAML key @c access in object */
+    uint8_t access;
+    /**
+     * @c type is taken from YAML key @c type in object
+     * optional; 0 is default value means @c NONE type
+     */
+    uint8_t type;
+    /**
+     * @c unit is taken from YAML key @c unit in object
+     * optional; 0 is default value
+     */
+    te_bool unit;
+    /**
+     * @c def_val is taken from YAML key @c default in object
+     * optional; NULL is default value
+     */
+    char *def_val;
+    /**
+     * @c volat is taken from YAML key @c volatile in object
+     * optional; 0 is default value
+     */
+    te_bool volat;
+    /**
+     * @c substitution is taken from YAML key @c substitution in object
+     * optional; 0 is default value
+     */
+    te_bool substitution;
+    /**
+     * @ no_parent_dep is taken from YAML key @c no_parent in object
+     * There is a logical negation.
+     * optional; 0 is default value
+     */
+    te_bool no_parent_dep;
+
+    /** @c depends array is taken from YAML key @c depends in object */
+    depends_entry *depends;
+    /** length of @c depends array */
+    unsigned int depends_count;
+} object_type;
+
+/** Structure for storing instance */
+typedef struct instance_type {
+    /**
+     * @c if_cond is taken from YAML key @c if in instance.
+     * The oid will be ignored iff the resolved value would be @c FALSE.
+     * CYAML doesn'know about this field.
+     */
+    char *if_cond; /* cyaml doesn't know about this field */
+
+    /** @c oid is taken from YAML key @c oid in instance */
+    char *oid;
+    /**
+     * @c value is taken from YAML key @c value in instance
+     * optional; NULL is default value
+     */
+    char *value;
+} instance_type;
+
+/**
+ * Structure for storing backup entry
+ * The only one of pointers is not @c NULL
+ */
+typedef struct backup_entry {
+    /** object */
+    object_type *object;
+    /** instance */
+    instance_type *instance;
+} backup_entry;
+
+/** Structure for storing the whole backup. */
+typedef struct backup_seq {
+    /** @c entries array is taken from the root YAML sequence */
+    backup_entry *entries;
+    /** length of @c entries array */
+    unsigned int entries_count;
+} backup_seq;
+
+/**
+ * Structure for storing @c cond node.
+ * cyaml doesn't know about this structure.
+ */
+typedef struct cond_entry {
+    /**
+     * @c if_cond is taken from YAML key @c if in @c cond node
+     * If the resolved value is TRUE then CS should consider @c then node.
+     * Otherwise @c else (if it exists).
+     */
+    char *if_cond;
+    /** @c then_cond is taken from YAML key @c then in @c cond node */
+    struct history_seq *then_cond;
+    /** @c else_cond is taken from YAML key @c else in @c cond node */
+    struct history_seq *else_cond;
+} cond_entry;
+
+/* Structure for storing entry of history.
+ * The only one pointer in not equal to @c NULL. */
+typedef struct history_entry {
+    /**
+     * @c comment is taken from YAML key @c comment in root sequence.
+     * It will be ignored.
+     * CYAML doesn'know about this field.
+     */
+    char *comment;
+
+    /**
+     * @c incl array is taken from YAML key @c include in root sequence.
+     * It consists of the names of configuration files that needs to include.
+     * CYAML doesn't know about this field.
+     */
+    char **incl;
+    /** length of @c incl array */
+    unsigned int incl_count;
+
+    /**
+     * @c cond is taken from YAML key @c cond.
+     * If resolved @c if is true then CS should consider @c then.
+     * Otherwise @c else (if it exists).
+     * CYAML doesn't know about this field.
+     */
+    cond_entry *cond;
+
+    /** @c reg array is taken from YAML key @c register in root sequence */
+    object_type *reg;
+    /** length of @c reg array */
+    unsigned int reg_count;
+
+    /** @c unreg array is taken from YAML key @c unregister in root sequence */
+    object_type *unreg;
+    /** length of @c unreg array */
+    unsigned int unreg_count;
+
+    /** @c add array is taken from YAML key @c add in root sequence */
+    instance_type *add;
+    /** length of @c add array */
+    unsigned int add_count;
+
+    /** @c get array is taken from YAML key @c get in root sequence */
+    instance_type *get;
+    /** length of @c get array */
+    unsigned int get_count;
+
+    /** @c delete array is taken from YAML key @c delete in root sequence */
+    instance_type *delete;
+    /** length of @c delete array */
+    unsigned int delete_count;
+
+    /** @c copy array is taken from YAML key @c copy in root sequence */
+    instance_type *copy;
+    /** length of @c copy array */
+    unsigned int copy_count;
+
+    /** @c set array is taken from YAML key @c set in root sequence */
+    instance_type *set;
+    /** length of @c set array */
+    unsigned int set_count;
+
+    /** name of reboote Test Agent */
+    char *reboot_ta; /* optional */
+} history_entry;
+
+/** Structure for storing the whole history */
+typedef struct history_seq {
+    /** @c entries array is taken from the root YAML sequence */
+    history_entry *entries;
+    /** length of @c entries array */
+    unsigned int entries_count;
+} history_seq;
+
+/**
+ * Free object.
+ *
+ * @param obj          object
+ */
+extern void cfg_yaml_free_obj(object_type *obj);
+
+/**
+ * Free instance.
+ *
+ * @param inst         instance
+ */
+extern void cfg_yaml_free_inst(instance_type *inst);
+
+/**
+ * Free sequense of history entries.
+ *
+ * @param hist_seq     sequence of history entries
+ */
+extern void cfg_yaml_free_hist_seq(history_seq *hist);
+
+/**
+ * Free sequense of backup entries.
+ *
+ * @param backup_seq     sequence of backup entries
+ */
+extern void cfg_yaml_free_backup_seq(backup_seq *backup);
+
+/**
+ * Save backup structure to yaml file.
+ *
+ * @param backup_seq     sequence of backup entries
+ */
+extern te_errno cfg_yaml_save_backup_file(const char *filename,
+                                          backup_seq *backup);
+
+/**
+ * Parse backup YAML file to backup structure.
+ *
+ * @param backup_seq     sequence of backup entries
+ */
+extern te_errno cfg_yaml_parse_backup_file(const char *filename,
+                                          backup_seq **backup);
+
+/**
+ * Save history structure known by CYAML to yaml file.
+ *
+ * @param hist_seq     sequence of history entries
+ */
+extern te_errno cfg_yaml_save_history_file(const char *filename,
+                                           history_seq *history);
+
+#endif /* __TE_CONF_CYAML_H__ */

--- a/engine/configurator/conf_defs.h
+++ b/engine/configurator/conf_defs.h
@@ -40,9 +40,6 @@
 #endif
 #include <sys/socket.h>
 
-#include <libxml/xmlmemory.h>
-#include <libxml/parser.h>
-
 #include "te_stdint.h"
 #include "te_errno.h"
 #include "te_defs.h"
@@ -68,17 +65,17 @@ cfg_instance_volatile(cfg_instance *inst)
 }
 
 /**
- * Process XML document containing dynamic history and
+ * Process structure containing dynamic history and
  * synchronise resulting database with Test Agents.
  *
- * @param root_node     Root node of the input document
- * @param expand_vars   List of key-value pairs for expansion in file,
+ * @param history       history structure
+ * @param expand_vars   list of key-value pairs for expansion in file
  *                      @c NULL if environment variables are used for
  *                      substitutions
  *
  * @return Status code.
  */
-extern te_errno parse_config_dh_sync(xmlNodePtr root_node,
+extern te_errno parse_config_dh_sync(history_seq *history,
                                      te_kvpair_h *expand_vars);
 
 #endif /* !__TE_CONF_DEFS_H__ */

--- a/engine/configurator/conf_dh.h
+++ b/engine/configurator/conf_dh.h
@@ -11,6 +11,7 @@
 #define __TE_CONF_DH_H__
 
 #include "te_vector.h"
+#include "conf_cyaml.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -21,7 +22,7 @@ extern "C" {
  * and add them to dynamic history.
  * Note: this routine does not reboot Test Agents.
  *
- * @param node          `<history>` node pointer
+ * @param history       history structure
  * @param expand_vars   List of key-value pairs for expansion in file,
  *                      @c NULL if environment variables are used for
  *                      substitutions
@@ -29,8 +30,9 @@ extern "C" {
  *
  * @return status code (errno.h)
  */
-extern int cfg_dh_process_file(xmlNodePtr node, te_kvpair_h *expand_vars,
-                               te_bool postsync);
+extern te_errno cfg_dh_process_file(history_seq *history,
+                                    te_kvpair_h *expand_vars,
+                                    te_bool postsync);
 
 /**
  * Create "history" configuration file with specified name.

--- a/engine/configurator/conf_main.c
+++ b/engine/configurator/conf_main.c
@@ -2941,13 +2941,7 @@ main(int argc, char **argv)
         goto exit;
     }
 
-    if ((filename = (char *)malloc(strlen(tmp_dir) +
-                                   strlen("/te_cfg_tmp.yml") + 1)) == NULL)
-    {
-        ERROR("No enough memory");
-        goto exit;
-    }
-    sprintf(filename, "%s/te_cfg_tmp.yml", tmp_dir);
+    filename = te_string_fmt("%s/te_cfg_tmp.yml", tmp_dir);
 
     if ((rc = cfg_db_init()) != 0)
     {

--- a/engine/configurator/conf_yaml.h
+++ b/engine/configurator/conf_yaml.h
@@ -20,15 +20,16 @@
  * for the objects maintained by the primary configuration file. The
  * instances may come with logical expressions either per individual
  * entry or per a bunch of entries to indicate conditions which must
- * be true for the instances to hit the XML document being generated.
+ * be true for the instances to hit the structure being generated.
  *
- * The XML document will be consumed directly by cfg_dh_process_file().
+ * The structure will be consumed directly by cfg_dh_process_file().
  *
  * @param filename          The input file path
  * @param expand_vars       List of key-value pairs for expansion in file,
  *                          @c NULL if environment variables are used for
  *                          substitutions
- * @param xn_history_root   XML node containing translated yaml file content,
+ * @param history_root      The structure containing translated yaml file
+ *                          content,
  *                          @c NULL if yaml file is not being included
  * @param conf_dirs         Directories where additionally Configurator should
  *                          search files via include directive
@@ -38,7 +39,6 @@
  */
 extern te_errno parse_config_yaml(const char *filename,
                                   te_kvpair_h *expand_vars,
-                                  xmlNodePtr xn_history_root,
+                                  history_seq *history_root,
                                   const char *conf_dirs);
-
 #endif /* __TE_CONF_YAML_H__ */

--- a/engine/configurator/meson.build
+++ b/engine/configurator/meson.build
@@ -46,6 +46,14 @@ if get_option('cs-conf-yaml')
     else
         missed_deps += 'yaml-0.1'
     endif
+
+    dep_cyaml = dependency('libcyaml', required: false)
+    required_deps += 'libcyaml'
+    if dep_cyaml.found()
+        te_cs_deps += dep_cyaml
+    else
+        missed_deps += 'libcyaml'
+    endif
 endif
 
 executable('te_cs', sources, install: true,

--- a/engine/configurator/meson.build
+++ b/engine/configurator/meson.build
@@ -15,6 +15,7 @@ sources = [
     'conf_backup.c',
     'conf_rcf.c',
     'conf_ta.c',
+    'conf_cyaml.c',
     'conf_print.c'
 ]
 

--- a/meson.build
+++ b/meson.build
@@ -76,7 +76,8 @@ deps_names_deb = {
     'openssl': 'libssl-dev',
     'pcap': 'libpcap-dev',
     'popt': 'libpopt-dev',
-    'yaml-0.1': 'libyaml-dev'
+    'yaml-0.1': 'libyaml-dev',
+    'libcyaml': 'libcyaml-dev'
 }
 deps_names_rpm = {
     'expect': 'expect-devel',
@@ -90,7 +91,8 @@ deps_names_rpm = {
     'openssl': 'openssl-devel',
     'pcap': 'libpcap-devel',
     'popt': 'popt-devel',
-    'yaml-0.1': 'libyaml-devel'
+    'yaml-0.1': 'libyaml-devel',
+    'libcyaml': 'libcyaml-devel'
 }
 
 missed_deps = []


### PR DESCRIPTION
The XML structures was used for temporary storing parsed
information from YAML configuration files. There was a decision
to eliminate XML from CS since there are some features that
doesn't provided by XML but only by YAML.

The fundamental idea behind CYAML is to allow applications to construct
schemas which describe both the permissible structure of the YAML
documents to read/write, and the C data structure(s) in which the loaded
data is arranged in memory. Nevertheless that CYAML couldn't handle
configuration files (they are not so simple as CYAML expected) it is
very convenient to use it for backup and for dynamic history files.

Note that since CYAML couldn't handle with YAML configuration files
there are some fields in the structures about which CYAML doesn't know
such as cond and include fields.

The parsing consist of two steps.
1) At the first step the configuration files are parsed to the
structure that has fields like cond and include that couldn't be
handled via CYAML.
2) The second step called reparse resolves include and cond fields.
Also it resolves oid and value of instance where some substitutions
are needed (for example of environment variables).