### PR TITLE
doc/cm: make interface ring sizes 64 bit

### DIFF
--- a/doc/cm/cm_base.yml
+++ b/doc/cm/cm_base.yml
@@ -757,7 +757,7 @@
 
     - oid: "/agent/interface/ring/rx/max"
       access: read_only
-      type: int32
+      type: int64
       d: |
          Advertised maximum for Rx ring size.
 
@@ -766,7 +766,7 @@
 
     - oid: "/agent/interface/ring/rx/current"
       access: read_write
-      type: int32
+      type: int64
       d: |
          Effective Rx ring size.
 
@@ -793,7 +793,7 @@
 
     - oid: "/agent/interface/ring/tx/max"
       access: read_only
-      type: int32
+      type: int64
       d: |
          Advertised maximum for Tx ring size.
 
@@ -802,7 +802,7 @@
 
     - oid: "/agent/interface/ring/tx/current"
       access: read_write
-      type: int32
+      type: int64
       d: |
          Effective Tx ring size.
 

--- a/lib/tapi/tapi_cfg_if.c
+++ b/lib/tapi/tapi_cfg_if.c
@@ -228,6 +228,29 @@ tapi_cfg_if_common_get(const char *ta, const char *ifname, const char *field,
     return rc;
 }
 
+/**
+ * Get 64bit integer value of an interface field
+ *
+ * @param ta        Test agent name
+ * @param ifname    Interface name
+ * @param field     Field name
+ * @param val       The value location
+ *
+ * @return Status code
+ */
+static te_errno
+tapi_cfg_if_common_get_int64(const char *ta, const char *ifname,
+                             const char *field, int64_t *val)
+{
+    int          rc;
+
+    if ((rc = cfg_get_int64(val, TE_CFG_TA_IF_FMT "/%s:",
+                            ta, ifname, field)) != 0)
+        ERROR("Failed to get %s value: %r", field, rc);
+
+    return rc;
+}
+
 /* See description in the tapi_cfg_if.h */
 te_errno
 tapi_cfg_if_gro_get(const char *ta, const char *ifname, int *gro)
@@ -259,25 +282,25 @@ tapi_cfg_if_flags_get(const char *ta, const char *ifname, int *flags)
 /* See description in the tapi_cfg_if.h */
 te_errno
 tapi_cfg_if_get_ring_size(const char *ta, const char *ifname,
-                          bool is_rx, int *ring_size)
+                          bool is_rx, int64_t *ring_size)
 {
     const char *path;
 
     path = is_rx ? "ring:/rx:/current" : "ring:/tx:/current";
 
-    return tapi_cfg_if_common_get(ta, ifname, path, ring_size);
+    return tapi_cfg_if_common_get_int64(ta, ifname, path, ring_size);
 }
 
 /* See description in the tapi_cfg_if.h */
 te_errno
 tapi_cfg_if_get_max_ring_size(const char *ta, const char *ifname,
-                              bool is_rx, int *max_ring_size)
+                              bool is_rx, int64_t *max_ring_size)
 {
     const char *path;
 
     path = is_rx ? "ring:/rx:/max" : "ring:/tx:/max";
 
-    return tapi_cfg_if_common_get(ta, ifname, path, max_ring_size);
+    return tapi_cfg_if_common_get_int64(ta, ifname, path, max_ring_size);
 }
 
 /**
@@ -297,6 +320,30 @@ tapi_cfg_if_common_set(const char *ta, const char *ifname,
     te_errno rc;
 
     if ((rc = cfg_set_instance_fmt(CVT_INT32, (void *)(intptr_t)val,
+                                   TE_CFG_TA_IF_FMT "/%s:", ta,
+                                   ifname, field)) != 0)
+        ERROR("Failed to set %s value: %r", field, rc);
+
+    return rc;
+}
+
+/**
+ * Set 64bit integer value of an interface field
+ *
+ * @param ta        Test agent name
+ * @param ifname    Interface name
+ * @param field     Field name
+ * @param val       The new value
+ *
+ * @return Status code
+ */
+static te_errno
+tapi_cfg_if_common_set_int64(const char *ta, const char *ifname,
+                             const char *field, int64_t val)
+{
+    te_errno rc;
+
+    if ((rc = cfg_set_instance_fmt(CFG_VAL(INT64, val),
                                    TE_CFG_TA_IF_FMT "/%s:", ta,
                                    ifname, field)) != 0)
         ERROR("Failed to set %s value: %r", field, rc);
@@ -335,23 +382,23 @@ tapi_cfg_if_flags_set(const char *ta, const char *ifname, int flags)
 /* See description in the tapi_cfg_if.h */
 te_errno
 tapi_cfg_if_set_ring_size(const char *ta, const char *ifname,
-                          bool is_rx, int ring_size)
+                          bool is_rx, int64_t ring_size)
 {
     const char *path;
 
     path = is_rx ? "ring:/rx:/current" : "ring:/tx:/current";
 
-    return tapi_cfg_if_common_set(ta, ifname, path, ring_size);
+    return tapi_cfg_if_common_set_int64(ta, ifname, path, ring_size);
 }
 
 /* See description in the tapi_cfg_if.h */
 te_errno
 tapi_cfg_if_set_ring_size_to_max(const char *ta, const char *ifname,
-                                 bool is_rx, int *ring_size)
+                                 bool is_rx, int64_t *ring_size)
 {
     te_errno rc;
-    int cur;
-    int max;
+    int64_t cur;
+    int64_t max;
 
     rc = tapi_cfg_if_get_max_ring_size(ta, ifname, is_rx, &max);
     if (rc != 0)

--- a/lib/tapi/tapi_cfg_if.h
+++ b/lib/tapi/tapi_cfg_if.h
@@ -199,7 +199,7 @@ extern te_errno tapi_cfg_if_flags_get(const char *ta, const char *ifname,
 extern te_errno tapi_cfg_if_get_ring_size(const char *ta,
                                           const char *ifname,
                                           bool is_rx,
-                                          int *ring_size);
+                                          int64_t *ring_size);
 
 /**
  * Get network interface Rx or Tx preset maximum ring size
@@ -214,7 +214,7 @@ extern te_errno tapi_cfg_if_get_ring_size(const char *ta,
 extern te_errno tapi_cfg_if_get_max_ring_size(const char *ta,
                                               const char *ifname,
                                               bool is_rx,
-                                              int *max_ring_size);
+                                              int64_t *max_ring_size);
 
 /**
  * Set GRO value of an ethernet interface
@@ -275,7 +275,7 @@ extern te_errno tapi_cfg_if_flags_set(const char *ta, const char *ifname,
  * @return Status code
  */
 extern te_errno tapi_cfg_if_set_ring_size(const char *ta, const char *ifname,
-                                          bool is_rx, int ring_size);
+                                          bool is_rx, int64_t ring_size);
 
 /**
  * Set network interface Rx or Tx ring size to its maximum
@@ -288,7 +288,7 @@ extern te_errno tapi_cfg_if_set_ring_size(const char *ta, const char *ifname,
  * @return Status code
  */
 extern te_errno tapi_cfg_if_set_ring_size_to_max(const char *ta, const char *ifname,
-                                                 bool is_rx, int *ring_size);
+                                                 bool is_rx, int64_t *ring_size);
 
 /**
  * Reset an ethernet interface


### PR DESCRIPTION
Some interfaces (representors) return 4294967295, which is a valid value but leads to testing failures since it can't be represented by int32.

Switching to int64 will prevent issues like this and preserve the current "return -1 if not supported" behaviour.

Testing done:
Creating representor interfaces no longer leads to failing reads from Configurator.
`tapi_cfg_if_set_ring_size` can still be called successfully.

Note to reviewers: I'm not sure if this is the right way to approach this issue. Alternatively, `eth_ring_size_get` could be modified to catch this value and return -1. If this is more preferable, what should be done with other values that can be interpreted as negative? I failed to find any information regarding the actual values the kernel can return here. Please advise.