### PR TITLE
Support DPDK FEC API

### DIFF
--- a/lib/rpcc_dpdk/ethdev.c
+++ b/lib/rpcc_dpdk/ethdev.c
@@ -714,7 +714,9 @@ tarpc_rte_eth_conf2str(te_log_buf *tlbp,
 
     te_log_buf_append(tlbp, "{ ");
 
-    te_log_buf_append(tlbp, "link_speeds=%#x, rxmode=", eth_conf->link_speeds);
+    te_log_buf_append(tlbp, "link_speeds=");
+    tarpc_rte_eth_speeds2str(tlbp, eth_conf->link_speeds);
+    te_log_buf_append(tlbp, ", rxmode=");
     tarpc_rte_eth_rxmode2str(tlbp, &eth_conf->rxmode);
     te_log_buf_append(tlbp, ", txmode=");
     tarpc_rte_eth_txmode2str(tlbp, &eth_conf->txmode);

--- a/lib/rpcc_dpdk/tapi_rpc_rte_ethdev.h
+++ b/lib/rpcc_dpdk/tapi_rpc_rte_ethdev.h
@@ -768,6 +768,49 @@ extern const char *tarpc_rte_eth_tunnel_type2str(
 extern const char * tarpc_rte_eth_dev_rss_types2str(te_log_buf *tlbp,
                                                     uint64_t rss_flow_types);
 
+/**
+ * @b rte_eth_fec_get_capability() RPC
+ *
+ * @param[in]  port_id        The port identifier of the device
+ * @param[in]  num            A number of elements in speed_fec_capa array
+ * @param[out] speed_fec_capa Per-speed capabilities
+ *
+ * @return
+ *   - A non-negative value lower or equal to num: success. The return value
+ *     is the number of entries filled in the fec capa array.
+ *   - A non-negative value higher than num: error, the given fec capa array
+ *     is too small. The return value corresponds to the num that should
+ *     be given to succeed. The entries in fec capa array are not valid and
+ *     shall not be used by the caller.
+ *   - jumps out on error (negative value)
+ */
+extern int rpc_rte_eth_fec_get_capability(
+                                rcf_rpc_server *rpcs, uint16_t port_id,
+                                struct tarpc_rte_eth_fec_capa *speed_fec_capa,
+                                unsigned int num);
+
+/**
+ * @b rte_eth_fec_get() RPC
+ *
+ * @param[in]  port_id     The port identifier of the device
+ * @param[out] fec_capa    A bitmask of enabled FEC modes
+ *
+ * @return @c 0 on success; jumps out on error (negative value)
+ */
+extern int rpc_rte_eth_fec_get(rcf_rpc_server *rpcs, uint16_t port_id,
+                               uint32_t *fec_capa);
+
+/**
+ * @b rte_eth_fec_set() RPC
+ *
+ * @param  port_id     The port identifier of the device
+ * @param  fec_capa    A bitmask of FEC modes to set
+ *
+ * @return @c 0 on success; jumps out on error (negative value)
+ */
+extern int rpc_rte_eth_fec_set(rcf_rpc_server *rpcs, uint16_t port_id,
+                               uint32_t fec_capa);
+
 /**@} <!-- END te_lib_rpc_rte_ethdev --> */
 
 #ifdef __cplusplus

--- a/lib/rpcxdr/tarpc_dpdk.x.m4
+++ b/lib/rpcxdr/tarpc_dpdk.x.m4
@@ -825,6 +825,26 @@ enum tarpc_eth_link_speeds {
     TARPC_RTE_ETH_LINK_SPEED__UNKNOWN_BIT
 };
 
+/** Numeric link speeds in Mbps */
+enum tarpc_eth_num_link_speeds {
+    TARPC_RTE_ETH_SPEED_NUM_NONE = 0,
+    TARPC_RTE_ETH_SPEED_NUM_10M = 10,
+    TARPC_RTE_ETH_SPEED_NUM_100M = 100,
+    TARPC_RTE_ETH_SPEED_NUM_1G = 1000,
+    TARPC_RTE_ETH_SPEED_NUM_2_5G = 2500,
+    TARPC_RTE_ETH_SPEED_NUM_5G = 5000,
+    TARPC_RTE_ETH_SPEED_NUM_10G = 10000,
+    TARPC_RTE_ETH_SPEED_NUM_20G = 20000,
+    TARPC_RTE_ETH_SPEED_NUM_25G = 25000,
+    TARPC_RTE_ETH_SPEED_NUM_40G = 40000,
+    TARPC_RTE_ETH_SPEED_NUM_50G = 50000,
+    TARPC_RTE_ETH_SPEED_NUM_56G = 56000,
+    TARPC_RTE_ETH_SPEED_NUM_100G = 100000,
+    TARPC_RTE_ETH_SPEED_NUM_200G = 200000,
+
+    TARPC_RTE_ETH_SPEED_NUM_UNKNOWN = INT_MAX
+};
+
 /** Device capabilities */
 enum tarpc_eth_dev_capa {
     TARPC_RTE_ETH_DEV_CAPA_RUNTIME_RX_QUEUE_SETUP_BIT = 0,
@@ -2328,6 +2348,65 @@ struct tarpc_rte_pktmbuf_calc_packet_crc_out {
     uint32_t             crc;
 };
 
+/** enum rte_eth_fec_mode */
+enum tarpc_rte_eth_fec_mode {
+    TARPC_RTE_ETH_FEC_NOFEC_BIT = 0,
+    TARPC_RTE_ETH_FEC_AUTO_BIT,
+    TARPC_RTE_ETH_FEC_BASER_BIT,
+    TARPC_RTE_ETH_FEC_RS_BIT,
+    TARPC_RTE_ETH_FEC_LLRS_BIT,
+
+    TARPC_RTE_ETH_FEC__UNKNOWN_BIT
+};
+
+/** struct rte_eth_fec_capa */
+struct tarpc_rte_eth_fec_capa {
+    uint32_t speed;
+    uint32_t capa;
+};
+
+/** rte_eth_fec_get_capability() */
+struct tarpc_rte_eth_fec_get_capability_in {
+    struct tarpc_in_arg           common;
+
+    uint16_t                      port_id;
+    struct tarpc_rte_eth_fec_capa speed_fec_capa<>;
+    unsigned int                  num;
+};
+
+struct tarpc_rte_eth_fec_get_capability_out {
+    struct tarpc_out_arg          common;
+
+    tarpc_int                     retval;
+    struct tarpc_rte_eth_fec_capa speed_fec_capa<>;
+};
+
+
+/** rte_eth_fec_get() */
+struct tarpc_rte_eth_fec_get_in {
+    struct tarpc_in_arg           common;
+
+    uint16_t                      port_id;
+    uint32_t                      fec_capa<>;
+};
+
+struct tarpc_rte_eth_fec_get_out {
+    struct tarpc_out_arg          common;
+
+    tarpc_int                     retval;
+    uint32_t                      fec_capa<>;
+};
+
+/** rte_eth_fec_set() */
+struct tarpc_rte_eth_fec_set_in {
+    struct tarpc_in_arg           common;
+
+    uint16_t                      port_id;
+    uint32_t                      fec_capa;
+};
+
+typedef struct tarpc_int_retval_out tarpc_rte_eth_fec_set_out;
+
 program dpdk
 {
     version ver0
@@ -2461,6 +2540,9 @@ program dpdk
         RPC_DEF(rte_eth_dev_tx_offload_name)
         RPC_DEF(rte_eth_representor_info_get)
         RPC_DEF(rte_eth_rx_metadata_negotiate)
+        RPC_DEF(rte_eth_fec_get_capability)
+        RPC_DEF(rte_eth_fec_get)
+        RPC_DEF(rte_eth_fec_set)
 
         RPC_DEF(rte_mk_flow_rule_components)
         RPC_DEF(rte_insert_flow_rule_items)


### PR DESCRIPTION
Testing done:
Tested with [dpdk-pmd-ts](https://github.com/Xilinx-CNS/cns-dpdk-pmd-ts) open-source repo.
A new test was implemented that uses the suggested API but it's private right now to avoid problems with building TE+TS.