### PR TITLE
lib/rpc: implement RPC function to calc CRC in mbuf

### DIFF
--- a/lib/rpcc_dpdk/mbuf.c
+++ b/lib/rpcc_dpdk/mbuf.c
@@ -1358,3 +1358,34 @@ rpc_rte_vlan_strip(rcf_rpc_server *rpcs,
 
     return out.retval;
 }
+
+int
+rpc_rte_pktmbuf_calc_packet_crc(rcf_rpc_server *rpcs,
+                                rpc_rte_mbuf_p m,
+                                te_bool crc_in_data,
+                                uint32_t *crc)
+{
+    tarpc_rte_pktmbuf_calc_packet_crc_in  in = {};
+    tarpc_rte_pktmbuf_calc_packet_crc_out out = {};
+
+    if (crc == NULL)
+    {
+        rpcs->_errno = TE_RC(TE_TAPI, TE_EINVAL);
+        RETVAL_INT(rte_pktmbuf_calc_packet_crc, -rpcs->_errno);
+    }
+
+    in.m = (tarpc_rte_mbuf)m;
+    in.crc_in_data = crc_in_data;
+
+    rcf_rpc_call(rpcs, "rte_pktmbuf_calc_packet_crc", &in, &out);
+
+    *crc = out.crc;
+
+    TAPI_RPC_LOG(rpcs, rte_pktmbuf_calc_packet_crc,
+                 RPC_PTR_FMT ", crc_in_data=%s",
+                 NEG_ERRNO_FMT ", crc=0x%" PRIX32,
+                 RPC_PTR_VAL(in.m), in.crc_in_data ? "TRUE" : "FALSE",
+                 NEG_ERRNO_ARGS(out.retval), out.crc);
+
+    RETVAL_ZERO_INT(rte_pktmbuf_calc_packet_crc, out.retval);
+}

--- a/lib/rpcc_dpdk/tapi_rpc_rte_mbuf.h
+++ b/lib/rpcc_dpdk/tapi_rpc_rte_mbuf.h
@@ -478,6 +478,20 @@ extern int rpc_rte_pktmbuf_redist(rcf_rpc_server *rpcs,
  */
 extern int rpc_rte_vlan_strip(rcf_rpc_server *rpcs, rpc_rte_mbuf_p m);
 
+/**
+ * Calculate CRC of a packet in the mbuf
+ *
+ * @param m               RTE mbuf pointer
+ * @param crc_in_data     Is CRC in packet data
+ * @param crc             Calculated CRC
+ *
+ * @return @c 0 on success; jumps out in case of failure
+ */
+extern int rpc_rte_pktmbuf_calc_packet_crc(rcf_rpc_server *rpcs,
+                                           rpc_rte_mbuf_p m,
+                                           te_bool crc_in_data,
+                                           uint32_t *crc);
+
 /**@} <!-- END te_lib_rpc_rte_mbuf --> */
 
 #ifdef __cplusplus

--- a/lib/rpcxdr/tarpc_dpdk.x.m4
+++ b/lib/rpcxdr/tarpc_dpdk.x.m4
@@ -2297,6 +2297,21 @@ struct tarpc_dpdk_find_representors_out {
     tarpc_int            retval;
 };
 
+/** rte_pktmbuf_calc_packet_crc() */
+struct tarpc_rte_pktmbuf_calc_packet_crc_in {
+    struct tarpc_in_arg  common;
+
+    tarpc_rte_mbuf       m;
+    tarpc_bool           crc_in_data;
+};
+
+struct tarpc_rte_pktmbuf_calc_packet_crc_out {
+    struct tarpc_out_arg common;
+
+    tarpc_int            retval;
+    uint32_t             crc;
+};
+
 program dpdk
 {
     version ver0
@@ -2346,6 +2361,7 @@ program dpdk
         RPC_DEF(rte_pktmbuf_get_tx_offload)
         RPC_DEF(rte_pktmbuf_set_tx_offload)
         RPC_DEF(rte_pktmbuf_refcnt_update)
+        RPC_DEF(rte_pktmbuf_calc_packet_crc)
 
         RPC_DEF(rte_pktmbuf_redist)
 


### PR DESCRIPTION
The new function uses DPDK CRC compute API to calculate the packet CRC that is placed in a given mbuf.

Tested with [dpdk-pmd-ts](https://github.com/Xilinx-CNS/cns-dpdk-pmd-ts) open-source repo.
A new test was implemented that uses the suggested API but it's private right now to avoid problems with building TE+TS.