### PR TITLE
engine/tester: emit argument hash for all iterations

### DIFF
--- a/engine/tester/run.c
+++ b/engine/tester/run.c
@@ -1694,21 +1694,21 @@ log_test_start(unsigned int flags,
             {
                 SET_JSON_INT(tmp, tin);
                 SET_NEW_JSON(result, "tin", tmp);
+            }
 
-                hash_str = test_params_hash(ctx->args, ri->n_args);
-                if (hash_str != NULL)
+            hash_str = test_params_hash(ctx->args, ri->n_args);
+            if (hash_str != NULL)
+            {
+                tmp = json_string(hash_str);
+                free(hash_str);
+                if (tmp == NULL)
                 {
-                    tmp = json_string(hash_str);
-                    free(hash_str);
-                    if (tmp == NULL)
-                    {
-                        ERROR("%s: json_string failed for hash_str",
-                              __FUNCTION__);
-                        json_decref(result);
-                        return;
-                    }
-                    SET_NEW_JSON(result, "hash", tmp);
+                    ERROR("%s: json_string failed for hash_str",
+                          __FUNCTION__);
+                    json_decref(result);
+                    return;
                 }
+                SET_NEW_JSON(result, "hash", tmp);
             }
 
 


### PR DESCRIPTION
When a test is run as part of a prologue, it does not get a TIN, and therefore does not emit its argument hash. This prevents some tools from telling different iterations of this test apart from each other.

Fix this problem by attaching the argument hash whenever it's possible.

Testing done: HTML logs now show argument hashes for prologue tests, bublik displays prologue arguments correctly now 