### PR TITLE
lib/rpcs_dpdk: add support of DEC_TTL action

### DIFF
--- a/lib/ndn/ndn_rte_flow.c
+++ b/lib/ndn/ndn_rte_flow.c
@@ -59,6 +59,7 @@ asn_enum_entry_t _ndn_rte_flow_action_type_enum_entries[] = {
     {"port-representor", NDN_FLOW_ACTION_TYPE_PORT_REPRESENTOR},
     {"represented-port", NDN_FLOW_ACTION_TYPE_REPRESENTED_PORT},
     {"jump", NDN_FLOW_ACTION_TYPE_JUMP},
+    {"dec-ttl", NDN_FLOW_ACTION_TYPE_DEC_TTL},
 };
 
 asn_type ndn_rte_flow_action_type_s = {

--- a/lib/ndn/ndn_rte_flow.h
+++ b/lib/ndn/ndn_rte_flow.h
@@ -52,6 +52,7 @@ typedef enum {
     NDN_FLOW_ACTION_TYPE_PORT_REPRESENTOR,
     NDN_FLOW_ACTION_TYPE_REPRESENTED_PORT,
     NDN_FLOW_ACTION_TYPE_JUMP,
+    NDN_FLOW_ACTION_TYPE_DEC_TTL,
 } ndn_rte_flow_action_type_t;
 
 typedef enum {

--- a/lib/rpcs_dpdk/rte_flow_ndn.c
+++ b/lib/rpcs_dpdk/rte_flow_ndn.c
@@ -1907,6 +1907,17 @@ rte_flow_action_drop_from_pdu(__rte_unused const asn_value *conf_pdu,
 }
 
 static te_errno
+rte_flow_action_dec_ttl_from_pdu(__rte_unused const asn_value *conf_pdu,
+                                 struct rte_flow_action *action)
+{
+    if (action == NULL)
+        return TE_EINVAL;
+
+    action->type = RTE_FLOW_ACTION_TYPE_DEC_TTL;
+    return 0;
+}
+
+static te_errno
 rte_flow_action_flag_from_pdu(__rte_unused const asn_value *conf_pdu,
                               struct rte_flow_action *action)
 {
@@ -2283,6 +2294,7 @@ static const struct rte_flow_action_types_mapping {
     { NDN_FLOW_ACTION_TYPE_REPRESENTED_PORT,
       rte_flow_action_represented_port_from_pdu },
     { NDN_FLOW_ACTION_TYPE_JUMP, rte_flow_action_jump_from_pdu },
+    { NDN_FLOW_ACTION_TYPE_DEC_TTL, rte_flow_action_dec_ttl_from_pdu },
 };
 
 static te_errno

--- a/lib/tapi_dpdk/tapi_rte_flow.c
+++ b/lib/tapi_dpdk/tapi_rte_flow.c
@@ -185,6 +185,19 @@ tapi_rte_flow_add_ndn_action_jump(asn_value *ndn_actions,
 }
 
 void
+tapi_rte_flow_add_ndn_action_dec_ttl(asn_value *ndn_actions, int action_index)
+{
+    asn_value *dec_ttl_action;
+
+    dec_ttl_action = asn_init_value(ndn_rte_flow_action);
+    CHECK_NOT_NULL(dec_ttl_action);
+
+    CHECK_RC(asn_write_int32(dec_ttl_action, NDN_FLOW_ACTION_TYPE_DEC_TTL, "type"));
+
+    CHECK_RC(asn_insert_indexed(ndn_actions, dec_ttl_action, action_index, ""));
+}
+
+void
 tapi_rte_flow_add_ndn_item_port(ndn_rte_flow_item_type_t type,
                                 uint32_t ethdev_port_id,
                                 asn_value *items,

--- a/lib/tapi_dpdk/tapi_rte_flow.h
+++ b/lib/tapi_dpdk/tapi_rte_flow.h
@@ -139,6 +139,15 @@ extern void tapi_rte_flow_add_ndn_action_jump(asn_value *ndn_actions,
                                               uint32_t group);
 
 /**
+ * Add a TTL decrease action to an action list at specified index.
+ *
+ * @param[in,out] ndn_actions       Action list
+ * @param[in]     action_index      Index at which the action is put to list
+ */
+extern void tapi_rte_flow_add_ndn_action_dec_ttl(asn_value *ndn_actions,
+                                                 int action_index);
+
+/**
  * Add an item of type PORT_REPRESENTOR / REPRESENTED_PORT to the item list.
  *
  * @param[in]     type            The item type


### PR DESCRIPTION
Now TTL decrease flow rule action can be inserted in list of actions.

Made similar to the other actions.