### PR TITLE
lib/confapi: safely add instances with large values

### DIFF
--- a/lib/confapi/conf_messages.h
+++ b/lib/confapi/conf_messages.h
@@ -161,7 +161,7 @@ typedef struct cfg_add_msg {
     cfg_handle      handle;         /**< OUT: object instance handle */
     te_bool         local;          /**< Local add */
     cfg_val_type    val_type;       /**< Object value type */
-    uint8_t         oid_offset;     /**< Offset to OID from the
+    uint16_t        oid_offset;     /**< Offset to OID from the
                                          message start */
     union {
         struct sockaddr val_addr[0];    /**< start of sockaddr value */


### PR DESCRIPTION
CFG_ADD messages include an 8-bit offset to the new instance's OID, starting from the beginning of the message. Since OIDs are placed after instance values, this practically limits the possible size of values that can be added to less than 256 bytes. This is lower than Configurator's internal limit of RCF_MAX_VAL (currently 1024 bytes).

This makes adding sufficiently large values impossible, which can be a problem when dealing with potentially large strings like process options, environmental variables, Open vSwitch flow rules, etc.

Fix this by making the offset 16-bit.

Testing done: tested by adding long Open vSwitch flow rules to Configurator; without this patch Configurator either goes into an infinite loop, fails with IPC-ECONNRESET or tries to process garbage values where part of the value is overwritten by OID