### PR TITLE
Allow routed and NATted TAPI network configurations

### DIFF
--- a/agents/unix/conf/base/conf_iptables.c
+++ b/agents/unix/conf/base/conf_iptables.c
@@ -810,7 +810,7 @@ iptables_rules_set(unsigned int  gid, const char *oid,
         len = (p != NULL) ? (p - value) : (int)strlen(value);
         /* prepare format string */
         sprintf(buf, "-A %%s_%%s %%.%ds\n", len);
-        fprintf(fp, buf, ifname, chain, value);
+        fprintf(fp, buf, chain, ifname, value);
 
         if (p != NULL)
             value = p + 1;

--- a/agents/unix/conf/base/conf_iptables.c
+++ b/agents/unix/conf/base/conf_iptables.c
@@ -793,7 +793,7 @@ iptables_rules_set(unsigned int  gid, const char *oid,
         return pid;
     }
 
-    if ((fp = fdopen(in_fd, "r")) == NULL)
+    if ((fp = fdopen(in_fd, "w")) == NULL)
     {
         ERROR("failed to get shell command execution result");
         rc = TE_RC(TE_TA_UNIX, TE_EFAULT);

--- a/doc/cm/cm_base.yml
+++ b/doc/cm/cm_base.yml
@@ -70,7 +70,15 @@
       access: read_write
       type: int32
       d: |
-         IP forwarding enabling/disabling.
+         IPv4 forwarding enabling/disabling.
+         Name:  empty
+         Limit: 1
+
+    - oid: "/agent/ip6_fw"
+      access: read_write
+      type: bool
+      d: |
+         IPv6 forwarding enabling/disabling.
          Name:  empty
          Limit: 1
 

--- a/doc/cm/cm_iptables.yml
+++ b/doc/cm/cm_iptables.yml
@@ -19,7 +19,7 @@
       type: none
       d: |
          Root object of iptables rules for the specific interface.
-         Name: empty
+         Name: IP version, 4 or 6
 
     - oid: "/agent/interface/iptables/table"
       access: read_only

--- a/doc/cm/cm_net.yml
+++ b/doc/cm/cm_net.yml
@@ -45,6 +45,33 @@
          Name: Target network
          Value: Instance name of the gateway node
 
+    - oid: "/net/nat"
+      access: read_write
+      type: bool
+      d: |
+         Whether this network is hidden behind NAT.
+         Only applicable to non-virtual networks.
+         Needs to be enabled explicitly.
+         Name: Empty
+         Value: Boolean value
+
+    - oid: "/net/nat/setup"
+      access: read_write
+      type: string
+      d: |
+         NAT setup procedure.
+         Name: Empty
+         Value: "none" or "iptables"
+
+
+    - oid: "/net/nat/forward"
+      access: read_create
+      type: string
+      d: |
+         Rules for port forwarding.
+         Name: Source network name[:protocol[:port-range]]
+         Value: Node name within the network
+
     - oid: "/net/ip4_subnet"
       access: read_create
       type: address

--- a/doc/cm/cm_net.yml
+++ b/doc/cm/cm_net.yml
@@ -20,6 +20,31 @@
          Root object of the network configuration tree.
          Name: network name
 
+    - oid: "/net/virtual"
+      access: read_write
+      type: bool
+      d: |
+         Whether the network is virtual, false by default.
+
+         Testing environment can be bound to a virtual network to employ nodes
+         from multiple "real" networks without assigning them IP addresses from
+         a common IP subnet.
+
+         To make sure that these nodes can reach each other, networking routes
+         can be installed on each node of all involved "real" networks.
+
+         Name: Empty
+         Value: Boolean value
+
+    - oid: "/net/gateway"
+      access: read_create
+      type: string
+      d: |
+         Network node that needs to be used as the gateway when setting up
+         routing rules for a given target network.
+         Name: Target network
+         Value: Instance name of the gateway node
+
     - oid: "/net/ip4_subnet"
       access: read_create
       type: address
@@ -51,6 +76,10 @@
                 E.g.: /agent:bridge/port:20
                 Note that nodes of type bridge are identified as nodes of
                 type nut.
+
+                For nodes of a virtual network the value is in the following format:
+                /net:<net_name>/node:<node_name>
+                E.g.: /net:net1/node:A
 
     - oid: "/net/node/type"
       access: read_write

--- a/lib/tapi/tapi_cfg_iptables.h
+++ b/lib/tapi/tapi_cfg_iptables.h
@@ -67,6 +67,41 @@ extern te_errno tapi_cfg_iptables_cmd_fmt(const char *ta, const char *ifname,
                                           const char *rule, ...);
 
 /**
+ * Set iptables rules for the specified chain
+ *
+ * @param ta            Test agent name.
+ * @param ifname        Interface name.
+ * @param af            Address family.
+ * @param table         Table to operate with (raw, filter, mangle, nat).
+ * @param chain         Chain name to operate with (without prefix).
+ * @param rules         Rules to add.
+ *
+ * @return              Status of the operation.
+ */
+extern te_errno tapi_cfg_iptables_rules(const char *ta, const char *ifname,
+                                        unsigned int af, const char *table,
+                                        const char *chain, const char *rules);
+
+/**
+ * Set iptables rules for the specified chain. The rules are specified
+ * using a format string with arguments.
+ *
+ * @param ta            Test agent name.
+ * @param ifname        Interface name.
+ * @param af            Address family.
+ * @param table         Table to operate with (raw, filter, mangle, nat).
+ * @param chain         Chain name to operate with (without prefix).
+ * @param rules         Rules to add.
+ *
+ * @return              Status of the operation.
+ */
+extern te_errno tapi_cfg_iptables_rules_fmt(const char *ta, const char *ifname,
+                                            unsigned int af, const char *table,
+                                            const char *chain,
+                                            const char *rules, ...)
+                                          __attribute__((format(printf, 6, 7)));
+
+/**
  * Install or delete jumping rule for the per-interface chain
  *
  * @param ta            - Test agent name

--- a/lib/tapi/tapi_cfg_iptables.h
+++ b/lib/tapi/tapi_cfg_iptables.h
@@ -44,6 +44,7 @@ extern "C" {
  */
 extern te_errno tapi_cfg_iptables_cmd(const char *ta,
                                       const char *ifname,
+                                      unsigned int af,
                                       const char *table,
                                       const char *chain,
                                       const char *rule);
@@ -61,7 +62,8 @@ extern te_errno tapi_cfg_iptables_cmd(const char *ta,
  * @return              Status of the operation
  */
 extern te_errno tapi_cfg_iptables_cmd_fmt(const char *ta, const char *ifname,
-                                          const char *table, const char *chain,
+                                          unsigned int af, const char *table,
+                                          const char *chain,
                                           const char *rule, ...);
 
 /**
@@ -77,6 +79,7 @@ extern te_errno tapi_cfg_iptables_cmd_fmt(const char *ta, const char *ifname,
  */
 extern te_errno tapi_cfg_iptables_chain_set(const char *ta,
                                             const char *ifname,
+                                            unsigned int af,
                                             const char *table,
                                             const char *chain,
                                             te_bool enable);
@@ -94,6 +97,7 @@ extern te_errno tapi_cfg_iptables_chain_set(const char *ta,
  */
 extern te_errno tapi_cfg_iptables_chain_add(const char *ta,
                                             const char *ifname,
+                                            unsigned int af,
                                             const char *table,
                                             const char *chain,
                                             te_bool enable);
@@ -110,6 +114,7 @@ extern te_errno tapi_cfg_iptables_chain_add(const char *ta,
  */
 extern te_errno tapi_cfg_iptables_chain_del(const char *ta,
                                             const char *ifname,
+                                            unsigned int af,
                                             const char *table,
                                             const char *chain);
 

--- a/lib/tapi/tapi_cfg_net.h
+++ b/lib/tapi/tapi_cfg_net.h
@@ -14,6 +14,7 @@
 
 #include "conf_api.h"
 #include "tapi_cfg_pci.h"
+#include "te_kvpair.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -54,7 +55,9 @@ typedef struct cfg_net_node_t {
 /** Net description structure */
 typedef struct cfg_net_t {
     char           *name;       /**< Network instance name */
+    te_bool         is_virtual; /**< Is network virtual? */
     cfg_handle      handle;     /**< Cfg instance handle */
+    te_kvpair_h     gateways;   /**< Gateway nodes */
     unsigned int    n_nodes;    /**< Number of nodes in the net */
     cfg_net_node_t *nodes;      /**< Array with net nodes */
 } cfg_net_t;
@@ -433,6 +436,17 @@ extern int tapi_cfg_net_assign_ip_one_end(unsigned int af, cfg_net_t *net,
                                           tapi_cfg_net_assigned *assigned);
 
 /**
+ * Get gateway node between two given networks.
+ *
+ * @param       net_src             Source network.
+ * @param       net_tgt             Target network.
+ *
+ * @return Network node.
+ */
+cfg_net_node_t *
+tapi_cfg_net_get_gateway(const cfg_net_t *net_src, const cfg_net_t *net_tgt);
+
+/**
  * Obtain information about subnet address and prefix length.
  *
  * @param assigned    subnet assignments handle
@@ -452,6 +466,15 @@ extern te_errno tapi_cfg_net_assigned_get_subnet_ip(
  * @return Status code (see te_errno.h)
  */
 extern te_errno tapi_cfg_net_delete_all(void);
+
+/**
+ * Create routes within virtual networks.
+ *
+ * @param af            Address family.
+ *
+ * @return Status code (see te_errno.h).
+ */
+extern te_errno tapi_cfg_net_create_routes(unsigned int af);
 
 /**
  * Get PCI devices associated with a network node.

--- a/lib/tapi/tapi_cfg_net.h
+++ b/lib/tapi/tapi_cfg_net.h
@@ -52,10 +52,18 @@ typedef struct cfg_net_node_t {
     enum net_node_rsrc_type rsrc_type;  /**< Node resource type */
 } cfg_net_node_t;
 
+/** Supported NAT setup procedures */
+typedef enum cfg_nat_setup_t {
+    NET_NAT_SETUP_NONE = 0,
+    NET_NAT_SETUP_IPTABLES,
+} cfg_nat_setup_t;
+
 /** Net description structure */
 typedef struct cfg_net_t {
     char           *name;       /**< Network instance name */
     te_bool         is_virtual; /**< Is network virtual? */
+    te_bool         nat;        /**< Is network behind NAT? */
+    cfg_nat_setup_t nat_setup;  /**< NAT setup procedure */
     cfg_handle      handle;     /**< Cfg instance handle */
     te_kvpair_h     gateways;   /**< Gateway nodes */
     unsigned int    n_nodes;    /**< Number of nodes in the net */
@@ -475,6 +483,15 @@ extern te_errno tapi_cfg_net_delete_all(void);
  * @return Status code (see te_errno.h).
  */
 extern te_errno tapi_cfg_net_create_routes(unsigned int af);
+
+/**
+ * Create iptables for NAT networks.
+ *
+ * @param af            Address family.
+ *
+ * @return Status code (see te_errno.h).
+ */
+extern te_errno tapi_cfg_net_create_nat(unsigned int af);
 
 /**
  * Get PCI devices associated with a network node.

--- a/lib/tapi_env/env_gram.y
+++ b/lib/tapi_env/env_gram.y
@@ -358,6 +358,7 @@ address:
         {
             p->name = name;
             name = NULL;
+            p->source = NULL;
             p->iface = curr_host_if;
             p->family = $5;
             p->type = $7;
@@ -365,6 +366,32 @@ address:
             CIRCLEQ_INSERT_TAIL(&env->addrs, p, links);
         }
         free(name);
+    }
+    |
+    ADDRESS COLON quotedname COLON ADDR_FAMILY COLON ADDR_TYPE COLON quotedname
+    {
+        char            *name = $3;
+        char            *source = $9;
+        tapi_env_addr   *p = calloc(1, sizeof(*p));
+
+        if (curr_host_if == NULL)
+            curr_host_if = create_host_if();
+
+        assert(p != NULL);
+        if (p != NULL)
+        {
+            p->name = name;
+            name = NULL;
+            p->source = source;
+            source = NULL;
+            p->iface = curr_host_if;
+            p->family = $5;
+            p->type = $7;
+            p->handle = CFG_HANDLE_INVALID;
+            CIRCLEQ_INSERT_TAIL(&env->addrs, p, links);
+        }
+        free(name);
+        free(source);
     }
     ;
 

--- a/lib/tapi_env/env_lex.l
+++ b/lib/tapi_env/env_lex.l
@@ -37,7 +37,7 @@ IUT|tester|IUT_PEER {
 	return ENTITY_TYPE;
 }
 
-loopback|unicast|broadcast|wildcard|alien|multicast|fake|ip4mapped_uc|mcast_all_hosts|linklocal|sitelocal {
+loopback|unicast|broadcast|wildcard|alien|multicast|fake|ip4mapped_uc|mcast_all_hosts|linklocal|sitelocal|external {
     yylval.number = (strcmp(yytext, "loopback") == 0) ?
                         TAPI_ENV_ADDR_LOOPBACK :
                     (strcmp(yytext, "unicast") == 0) ?
@@ -58,6 +58,8 @@ loopback|unicast|broadcast|wildcard|alien|multicast|fake|ip4mapped_uc|mcast_all_
                         TAPI_ENV_ADDR_LINKLOCAL :
                     (strcmp(yytext, "sitelocal") == 0) ?
                         TAPI_ENV_ADDR_SITELOCAL :
+                    (strcmp(yytext, "external") == 0) ?
+                        TAPI_ENV_ADDR_EXTERNAL :
                         TAPI_ENV_ADDR_FAKE_UNICAST;
     return ADDR_TYPE;
 }

--- a/lib/tapi_env/tapi_env.h
+++ b/lib/tapi_env/tapi_env.h
@@ -317,6 +317,8 @@ typedef enum {
     TAPI_ENV_ADDR_IP4MAPPED_UC,     /**< Unicast IPv4-mapped IPv6 address */
     TAPI_ENV_ADDR_LINKLOCAL,        /**< Link-local IPv6 address */
     TAPI_ENV_ADDR_SITELOCAL,        /**< Site-local IPv6 address */
+    TAPI_ENV_ADDR_EXTERNAL,         /**< IP address visible from outside
+                                         the network */
     TAPI_ENV_ADDR_INVALID,
 } tapi_env_addr_type;
 
@@ -463,6 +465,7 @@ typedef struct tapi_env_addr {
     CIRCLEQ_ENTRY(tapi_env_addr)    links;  /**< Links */
 
     char                   *name;       /**< Name of the address */
+    char                   *source;     /**< Name of the source address */
 
     tapi_env_if            *iface;      /**< Host interface the address
                                              belongs to */

--- a/lib/tapi_env/tapi_env.h
+++ b/lib/tapi_env/tapi_env.h
@@ -171,6 +171,28 @@
     } while (0)
 
 /**
+ * Get address and assign port from another address. Names of the variables must
+ * match name of the addresses in environment configuration string. Source
+ * address must already be initialized.
+ *
+ * @param      pco_     RPC server to use when checking the port.
+ * @param      src_     Address whose port to use (const struct sockaddr *).
+ * @param[out] addr_    Address (const struct sockaddr *).
+ */
+#define TEST_GET_ADDR_REUSE_PORT(pco_, src_, addr_) \
+    do {                                                     \
+        uint16_t *addr_port_ptr;                             \
+        uint16_t *src_port_ptr;                              \
+        TEST_GET_ADDR_NO_PORT(addr_);                        \
+        addr_port_ptr = te_sockaddr_get_port_ptr(addr_);     \
+        src_port_ptr = te_sockaddr_get_port_ptr(src_);       \
+        if (addr_port_ptr == NULL || src_port_ptr == NULL) { \
+            ERROR("Failed to extract port pointers");        \
+            TEST_STOP;                                       \
+        }                                                    \
+        *addr_port_ptr = *src_port_ptr;                      \
+    } while (0)
+/**
  * Check that the address is fake. Name of the variable must
  * match name of the address in environment configuration string.
  *

--- a/lib/tapi_rpc/tapi_netns.c
+++ b/lib/tapi_rpc/tapi_netns.c
@@ -141,20 +141,20 @@ tapi_netns_create_ns_with_net_channel(const char *ta, const char *ns_name,
                                        prefix, FALSE, NULL));
 
     /* iptables -t nat -A POSTROUTING -o ctl_if -j MASQUERADE");*/
-    CHRC(tapi_cfg_iptables_chain_add(ta, veth1, "nat", "NS_MASQUERADE",
+    CHRC(tapi_cfg_iptables_chain_add(ta, veth1, AF_INET, "nat", "NS_MASQUERADE",
                                      FALSE));
-    CHRC(tapi_cfg_iptables_cmd_fmt(ta, veth1, "nat", "NS_MASQUERADE",
+    CHRC(tapi_cfg_iptables_cmd_fmt(ta, veth1, AF_INET, "nat", "NS_MASQUERADE",
                                        "-A POSTROUTING -o %s -j", ctl_if));
-    CHRC(tapi_cfg_iptables_cmd(ta, veth1, "nat",
+    CHRC(tapi_cfg_iptables_cmd(ta, veth1, AF_INET, "nat",
                                    "NS_MASQUERADE", "-A -j MASQUERADE"));
 
     /* iptables -t nat -A PREROUTING -p tcp --dport rcfport -j DNAT
      *          --to-destination addr_str2:rcfport  */
-    CHRC(tapi_cfg_iptables_chain_add(ta, veth1, "nat", "NS_PORT_FW", FALSE));
-    CHRC(tapi_cfg_iptables_cmd_fmt(ta, veth1, "nat", "NS_PORT_FW",
+    CHRC(tapi_cfg_iptables_chain_add(ta, veth1, AF_INET, "nat", "NS_PORT_FW", FALSE));
+    CHRC(tapi_cfg_iptables_cmd_fmt(ta, veth1, AF_INET, "nat", "NS_PORT_FW",
                                    "-A PREROUTING -p tcp --dport %d -j",
                                    rcfport));
-    CHRC(tapi_cfg_iptables_cmd_fmt(ta, veth1, "nat", "NS_PORT_FW",
+    CHRC(tapi_cfg_iptables_cmd_fmt(ta, veth1, AF_INET, "nat", "NS_PORT_FW",
                                    "-A -p tcp -j DNAT --to-destination %s:%d",
                                    addr_str2, rcfport));
 


### PR DESCRIPTION
This patch series fixes several issues with the current iptables integration in TE and implements a mechanism to allow tests to set up network configurations where nodes are in different subnets, some of which can be behind NAT.

Testing done: tested by adding new configurations to vswitch-ts