### PR TITLE
Allow changing various useful Open vSwitch policies

### DIFF
--- a/agents/unix/conf/ovs/conf_ovs.c
+++ b/agents/unix/conf/ovs/conf_ovs.c
@@ -189,7 +189,7 @@ static const char *bridge_datapath_types[] = { "system", "netdev", NULL };
 static const char *other_config_types[] = {
     "dpdk-alloc-mem", "dpdk-socket-mem", "dpdk-lcore-mask",
     "dpdk-hugepage-dir", "dpdk-socket-limit", "dpdk-extra", "hw-offload",
-    NULL
+    "tc-policy", NULL
 };
 
 static const char *vlan_types[] = { "trunk", "access", "dot1q-tunnel",

--- a/agents/unix/conf/ovs/conf_ovs.c
+++ b/agents/unix/conf/ovs/conf_ovs.c
@@ -189,7 +189,7 @@ static const char *bridge_datapath_types[] = { "system", "netdev", NULL };
 static const char *other_config_types[] = {
     "dpdk-alloc-mem", "dpdk-socket-mem", "dpdk-lcore-mask",
     "dpdk-hugepage-dir", "dpdk-socket-limit", "dpdk-extra", "hw-offload",
-    "tc-policy", NULL
+    "tc-policy", "max-idle", "max-revalidator", NULL
 };
 
 static const char *vlan_types[] = { "trunk", "access", "dot1q-tunnel",


### PR DESCRIPTION
These policies are required if tests need to enforce HW offloading in TC or reduce revalidation time for flows.

Testing done: tested using new package and configurations in vswitch-ts