### PR TITLE
Implement eswitch support

### DIFF
--- a/agents/unix/conf/base/conf.c
+++ b/agents/unix/conf/base/conf.c
@@ -528,6 +528,12 @@ static te_errno iface_parent_get(unsigned int, const char *, char *,
                                  const char *);
 static te_errno iface_kind_get(unsigned int, const char *, char *,
                                const char *);
+static te_errno iface_switch_id_get(unsigned int, const char *, char *,
+                                    const char *);
+static te_errno iface_port_id_get(unsigned int, const char *, char *,
+                                  const char *);
+static te_errno iface_port_name_get(unsigned int, const char *, char *,
+                                    const char *);
 
 static te_errno interface_list(unsigned int, const char *,
                                const char *, char **);
@@ -947,8 +953,20 @@ RCF_PCH_CFG_NODE_RO(node_iface_kind, "kind", NULL,
 RCF_PCH_CFG_NODE_RO(node_ifindex, "index", NULL, &node_iface_kind,
                     ifindex_get);
 
+RCF_PCH_CFG_NODE_RO(node_iface_port_name, "port_name",
+                    NULL, &node_ifindex,
+                    iface_port_name_get);
+
+RCF_PCH_CFG_NODE_RO(node_iface_port_id, "port_id",
+                    NULL, &node_iface_port_name,
+                    iface_port_id_get);
+
+RCF_PCH_CFG_NODE_RO(node_iface_switch_id, "switch_id",
+                    NULL, &node_iface_port_id,
+                    iface_switch_id_get);
+
 RCF_PCH_CFG_NODE_COLLECTION(node_interface, "interface",
-                            &node_ifindex, &node_arp_ignore_all,
+                            &node_iface_switch_id, &node_arp_ignore_all,
                             NULL, NULL, interface_list, NULL);
 
 RCF_PCH_CFG_NODE_RW(node_ip4_fw, "ip4_fw", NULL, &node_interface,
@@ -3369,6 +3387,9 @@ typedef enum {
     IF_PROP_PARENT = 0, /**< Parent interface. */
     IF_PROP_BCAST_ADDR, /**< Broadcast address. */
     IF_PROP_KIND,       /**< Interface kind (vlan, macvlan, ipvlan, etc). */
+    IF_PROP_SWITCH_ID,  /**< Switchdev switch ID */
+    IF_PROP_PORT_ID,    /**< Switchdev port ID */
+    IF_PROP_PORT_NAME,  /**< Switchdev port name */
 } if_property;
 
 /**
@@ -3468,6 +3489,48 @@ iface_get_property_netconf(const char *ifname,
                                   value, RCF_MAX_VAL);
                     break;
 
+                case IF_PROP_SWITCH_ID:
+                    if (link->switch_id != NULL)
+                    {
+                        size_t ret;
+                        ret = te_strlcpy(value, link->switch_id, RCF_MAX_VAL);
+                        if (ret == RCF_MAX_VAL)
+                        {
+                            ERROR("%s(): switch_id was too long",
+                                  __FUNCTION__);
+                            rc = TE_ESMALLBUF;
+                        }
+                    }
+                    break;
+
+                case IF_PROP_PORT_ID:
+                    if (link->port_id != NULL)
+                    {
+                        size_t ret;
+                        ret = te_strlcpy(value, link->port_id, RCF_MAX_VAL);
+                        if (ret == RCF_MAX_VAL)
+                        {
+                            ERROR("%s(): port_id was too long",
+                                  __FUNCTION__);
+                            rc = TE_ESMALLBUF;
+                        }
+                    }
+                    break;
+
+                case IF_PROP_PORT_NAME:
+                    if (link->port_name != NULL)
+                    {
+                        size_t ret;
+                        ret = te_strlcpy(value, link->port_name, RCF_MAX_VAL);
+                        if (ret == RCF_MAX_VAL)
+                        {
+                            ERROR("%s(): port_name was too long",
+                                  __FUNCTION__);
+                            rc = TE_ESMALLBUF;
+                        }
+                    }
+                    break;
+
                 default:
 
                     ERROR("%s(): unknown interface property requested",
@@ -3534,6 +3597,96 @@ get_interface_kind(const char *ifname, char *value)
 
 #ifdef USE_LIBNETCONF
     return iface_get_property_netconf(ifname, value, IF_PROP_KIND);
+#else
+    return TE_RC(TE_TA_UNIX, TE_ENOENT);
+#endif
+}
+
+/**
+ * Get instance value for object "agent/interface/switch_id".
+ *
+ * @param gid           Group identifier (unused).
+ * @param oid           Full identifier of the father instance (unused).
+ * @param value         Location for the switch ID.
+ * @param ifname        Interface name.
+ *
+ * @return              Status code.
+ */
+static te_errno
+iface_switch_id_get(unsigned int gid, const char *oid, char *value,
+                    const char *ifname)
+{
+    te_errno rc;
+
+    UNUSED(gid);
+    UNUSED(oid);
+
+    if ((rc = CHECK_INTERFACE(ifname)) != 0)
+        return TE_RC(TE_TA_UNIX, rc);
+
+#ifdef USE_LIBNETCONF
+    *value = '\0';
+    return iface_get_property_netconf(ifname, value, IF_PROP_SWITCH_ID);
+#else
+    return TE_RC(TE_TA_UNIX, TE_ENOENT);
+#endif
+}
+
+/**
+ * Get instance value for object "agent/interface/port_id".
+ *
+ * @param gid           Group identifier (unused).
+ * @param oid           Full identifier of the father instance (unused).
+ * @param value         Location for the port id.
+ * @param ifname        Interface name.
+ *
+ * @return              Status code.
+ */
+static te_errno
+iface_port_id_get(unsigned int gid, const char *oid, char *value,
+                  const char *ifname)
+{
+    te_errno rc;
+
+    UNUSED(gid);
+    UNUSED(oid);
+
+    if ((rc = CHECK_INTERFACE(ifname)) != 0)
+        return TE_RC(TE_TA_UNIX, rc);
+
+#ifdef USE_LIBNETCONF
+    *value = '\0';
+    return iface_get_property_netconf(ifname, value, IF_PROP_PORT_ID);
+#else
+    return TE_RC(TE_TA_UNIX, TE_ENOENT);
+#endif
+}
+
+/**
+ * Get instance value for object "agent/interface/port_name".
+ *
+ * @param gid           Group identifier (unused).
+ * @param oid           Full identifier of the father instance (unused).
+ * @param value         Location for the port name.
+ * @param ifname        Interface name.
+ *
+ * @return              Status code.
+ */
+static te_errno
+iface_port_name_get(unsigned int gid, const char *oid, char *value,
+                    const char *ifname)
+{
+    te_errno rc;
+
+    UNUSED(gid);
+    UNUSED(oid);
+
+    if ((rc = CHECK_INTERFACE(ifname)) != 0)
+        return TE_RC(TE_TA_UNIX, rc);
+
+#ifdef USE_LIBNETCONF
+    *value = '\0';
+    return iface_get_property_netconf(ifname, value, IF_PROP_PORT_NAME);
 #else
     return TE_RC(TE_TA_UNIX, TE_ENOENT);
 #endif

--- a/agents/unix/conf/base/conf.c
+++ b/agents/unix/conf/base/conf.c
@@ -535,6 +535,11 @@ static te_errno iface_port_id_get(unsigned int, const char *, char *,
 static te_errno iface_port_name_get(unsigned int, const char *, char *,
                                     const char *);
 
+static te_errno switchdev_name_get(unsigned int, const char *, char *,
+                                   const char *);
+static te_errno switchdev_name_list(unsigned int, const char *,
+                                    const char *, char **);
+
 static te_errno interface_list(unsigned int, const char *,
                                const char *, char **);
 
@@ -969,7 +974,11 @@ RCF_PCH_CFG_NODE_COLLECTION(node_interface, "interface",
                             &node_iface_switch_id, &node_arp_ignore_all,
                             NULL, NULL, interface_list, NULL);
 
-RCF_PCH_CFG_NODE_RW(node_ip4_fw, "ip4_fw", NULL, &node_interface,
+RCF_PCH_CFG_NODE_RO_COLLECTION(node_switchdev_name, "switchdev_name",
+                            NULL, &node_interface,
+                            switchdev_name_get, switchdev_name_list);
+
+RCF_PCH_CFG_NODE_RW(node_ip4_fw, "ip4_fw", NULL, &node_switchdev_name,
                     ip4_fw_get, ip4_fw_set);
 
 RCF_PCH_CFG_NODE_RW(node_ip6_fw, "ip6_fw", NULL, &node_ip4_fw,
@@ -3095,6 +3104,140 @@ vlans_del(unsigned int gid, const char *oid, const char *ifname,
 #else
     ERROR("This test agent does not support VLANs");
     return TE_RC(TE_TA_UNIX, TE_EOPNOTSUPP);
+#endif
+}
+
+/**
+ * Get instance value for object "agent/switchdev_name".
+ *
+ * @param gid           Group identifier (unused).
+ * @param oid           Full identifier of the father instance.
+ * @param value         Location for the interface name.
+ * @param id            (switch ID, port name) pair.
+ *
+ * @return              Status code.
+ */
+static te_errno
+switchdev_name_get(unsigned int gid, const char *oid, char *value,
+                   const char *id)
+{
+    UNUSED(gid);
+    UNUSED(oid);
+
+    if (id == NULL || *id == '\0')
+        return TE_RC(TE_TA_UNIX, TE_EINVAL);
+
+    char *sep = strchr(id, ':');
+    if (sep == NULL)
+        return TE_RC(TE_TA_UNIX, TE_EINVAL);
+
+    char *switch_id = strndup(id, sep - id);
+    char *port_name = strdup(sep + 1);
+
+#ifdef USE_LIBNETCONF
+    {
+        netconf_list       *links;
+        const netconf_node *node;
+
+        links = netconf_link_dump(nh);
+        if (links == NULL)
+            return TE_OS_RC(TE_TA_UNIX, errno);
+
+        for (node = links->head; node != NULL; node = node->next)
+        {
+            const netconf_link *link = &(node->data.link);
+
+            if (link->switch_id != NULL && link->port_name != NULL &&
+                strcmp(link->switch_id, switch_id) == 0 &&
+                strcmp(link->port_name, port_name) == 0)
+            {
+                te_errno rc = 0;
+                size_t   ret;
+
+                ret = te_strlcpy(value, link->ifname, RCF_MAX_VAL);
+                if (ret == RCF_MAX_VAL)
+                {
+                    ERROR("Failed to copy interface's base name");
+                    rc = TE_RC(TE_TA_UNIX, TE_ESMALLBUF);
+                }
+
+                free(switch_id);
+                free(port_name);
+                netconf_list_free(links);
+                return rc;
+            }
+        }
+        netconf_list_free(links);
+    }
+
+    free(switch_id);
+    free(port_name);
+
+    ERROR("Failed to find rep for '%s/%s'", switch_id, port_name);
+    return TE_RC(TE_TA_UNIX, TE_ENOENT);
+#else
+    value[0] = '\0';
+
+    return 0;
+#endif
+}
+
+/**
+ * Get instance list for object "agent/switchdev_name".
+ *
+ * @param gid           Group identifier (unused).
+ * @param oid           Full identifier of the father instance.
+ * @param sub_id        ID of the object to be listed (unused).
+ * @param list          Location for the list pointer.
+ *
+ * @return              Status code.
+ */
+static te_errno
+switchdev_name_list(unsigned int gid, const char *oid,
+                    const char *sub_id, char **list)
+{
+    UNUSED(gid);
+    UNUSED(oid);
+
+    te_string buffer = TE_STRING_INIT;
+
+#ifdef USE_LIBNETCONF
+    {
+        netconf_list       *links;
+        const netconf_node *node;
+
+        links = netconf_link_dump(nh);
+        if (links == NULL)
+            return TE_OS_RC(TE_TA_UNIX, errno);
+
+        for (node = links->head; node != NULL; node = node->next)
+        {
+            const netconf_link *link = &(node->data.link);
+
+            if (link->switch_id != NULL && link->port_name != NULL)
+            {
+                te_errno rc;
+
+                rc = te_string_append(&buffer, "%s:%s ", link->switch_id,
+                                      link->port_name);
+                if (rc != 0)
+                {
+                    ERROR("Failed to copy interface's switch_id and port_name");
+                    netconf_list_free(links);
+                    return TE_RC(TE_TA_UNIX, TE_ESMALLBUF);
+                }
+            }
+        }
+        netconf_list_free(links);
+    }
+
+    *list = buffer.ptr;
+
+    return 0;
+#else
+    value[0] = '\0';
+
+    return 0;
 #endif
 }
 

--- a/agents/unix/conf/base/conf_pci.c
+++ b/agents/unix/conf/base/conf_pci.c
@@ -2752,6 +2752,125 @@ out:
 #endif
 }
 
+/* Get PCI device eswitch mode */
+static te_errno
+pci_eswitch_mode_get(unsigned int gid, const char *oid, char *value,
+                     const char *unused1, const char *unused2,
+                     const char *addr_str)
+{
+    UNUSED(gid);
+    UNUSED(oid);
+    UNUSED(unused1);
+    UNUSED(unused2);
+
+#ifndef USE_LIBNETCONF
+    UNUSED(addr_str);
+
+    *value = '\0';
+    return 0;
+#else
+    te_errno rc = 0;
+    netconf_list *list = NULL;
+
+    rc = netconf_devlink_get_eswitch(nh_genl, "pci", addr_str, &list);
+    if (rc != 0)
+    {
+        if (rc == TE_ENODEV || rc == TE_ENOENT || rc == TE_EOPNOTSUPP ||
+            rc == TE_EPERM)
+        {
+            *value = '\0';
+            return 0;
+        }
+
+        return TE_RC(TE_TA_UNIX, rc);
+    }
+
+    if (list->length == 0)
+    {
+        *value = '\0';
+        netconf_list_free(list);
+        return 0;
+    }
+
+    rc = te_snprintf(value, RCF_MAX_VAL, "%s",
+                     netconf_devlink_eswitch_mode_netconf2str(
+                                        list->tail->data.devlink_eswitch.mode));
+    netconf_list_free(list);
+    if (rc != 0)
+    {
+        ERROR("%s(): te_snprintf() failed, rc=%r", __FUNCTION__, rc);
+        return TE_RC(TE_TA_UNIX, rc);
+    }
+
+    return 0;
+#endif
+}
+
+/* Set PCI device eswitch mode */
+static te_errno
+pci_eswitch_mode_set(unsigned int gid, const char *oid, const char *value,
+                     const char *unused1, const char *unused2,
+                     const char *addr_str)
+{
+    UNUSED(gid);
+    UNUSED(oid);
+    UNUSED(unused1);
+    UNUSED(unused2);
+
+#ifndef USE_LIBNETCONF
+    UNUSED(addr_str);
+
+    *value = '\0';
+    return 0;
+#else
+    te_errno rc = 0;
+    netconf_devlink_eswitch_mode mode;
+
+    mode = netconf_devlink_eswitch_mode_str2netconf(value);
+    if (mode == NETCONF_DEVLINK_ESWITCH_MODE_UNDEF)
+        return TE_RC(TE_TA_UNIX, TE_EINVAL);
+
+    rc = netconf_devlink_eswitch_mode_set(nh_genl, "pci", addr_str, mode);
+    if (rc != 0)
+        return TE_RC(TE_TA_UNIX, rc);
+
+    return 0;
+#endif
+}
+/* Get PCI device eswitch support */
+static te_errno
+pci_eswitch_get(unsigned int gid, const char *oid, char *value,
+                 const char *unused1, const char *unused2,
+                 const char *addr_str)
+{
+    UNUSED(gid);
+    UNUSED(oid);
+    UNUSED(unused1);
+    UNUSED(unused2);
+
+#ifndef USE_LIBNETCONF
+    UNUSED(addr_str);
+
+    *value = '\0';
+    return 0;
+#else
+    te_errno rc = 0;
+    netconf_list *list = NULL;
+
+    rc = netconf_devlink_get_eswitch(nh_genl, "pci", addr_str, &list);
+    netconf_list_free(list);
+
+    rc = te_snprintf(value, RCF_MAX_VAL, "%u", (rc == 0) ? 1 : 0);
+    if (rc != 0)
+    {
+        ERROR("%s(): te_snprintf() failed, rc=%r", __FUNCTION__, rc);
+        return TE_RC(TE_TA_UNIX, rc);
+    }
+
+    return 0;
+#endif
+}
+
 /* List parameter names of a PCI device */
 static te_errno
 pci_param_list(unsigned int gid, const char *oid,
@@ -3344,6 +3463,12 @@ RCF_PCH_CFG_NODE_RO(node_pci_sriov, "sriov",
                     &node_pci_sriov_vf, &node_pci_driver,
                     pci_sriov_get);
 
+RCF_PCH_CFG_NODE_RW(node_pci_eswitch_mode, "mode",
+                    NULL, NULL, pci_eswitch_mode_get, pci_eswitch_mode_set);
+
+RCF_PCH_CFG_NODE_RO(node_pci_eswitch, "eswitch",
+                    &node_pci_eswitch_mode, &node_pci_sriov, pci_eswitch_get);
+
 
 #define PCI_ID_NODE_RO(_name, _field, _fmt, _sibling)                   \
     static te_errno                                                     \
@@ -3371,7 +3496,7 @@ RCF_PCH_CFG_NODE_RO(node_pci_sriov, "sriov",
                         (_sibling),                                     \
                         pci_##_name##_get)
 
-PCI_ID_NODE_RO(class, device_class, "%08x", &node_pci_sriov);
+PCI_ID_NODE_RO(class, device_class, "%08x", &node_pci_eswitch);
 PCI_ID_NODE_RO(subsystem_device, subsystem_device, "%04x", &node_pci_class);
 PCI_ID_NODE_RO(subsystem_vendor, subsystem_vendor, "%04x",
                &node_pci_subsystem_device);

--- a/doc/cm/cm_base.yml
+++ b/doc/cm/cm_base.yml
@@ -74,6 +74,19 @@
          Name:  empty
          Limit: 1
 
+    - oid: "/agent/switchdev_name"
+      access: read_only
+      type: string
+      # Exclude from the rollback process to avoid timing issues
+      volatile: true
+      depends:
+        - oid: "/agent/hardware/pci/device/driver"
+        - oid: "/agent/hardware/pci/device/sriov/num_vfs"
+      d: |
+        Name of the interface identified by switchid/portname pair.
+        Name: switchid:portname
+        Value: interface name
+
     - oid: "/agent/interface"
       access: read_only
       type: none
@@ -88,6 +101,24 @@
       d: |
          Network interface
          Name: "eth0"-like
+
+    - oid: "/agent/interface/switch_id"
+      access: read_only
+      type: string
+      d: |
+        Switchdev switch ID
+
+    - oid: "/agent/interface/port_id"
+      access: read_only
+      type: string
+      d: |
+        Switchdev port ID
+
+    - oid: "/agent/interface/port_name"
+      access: read_only
+      type: string
+      d: |
+        Switchdev port name
 
     - oid: "/agent/interface/index"
       access: read_only

--- a/doc/cm/cm_pci.yml
+++ b/doc/cm/cm_pci.yml
@@ -199,6 +199,26 @@
          Name: ordinal number of a VF
          Value: an OID of a VF
 
+    - oid: "/agent/hardware/pci/device/eswitch"
+      access: read_only
+      type: bool
+      depends:
+        - oid: "/agent/hardware/pci/device/driver"
+      d: |
+         Availability of eswitch interface on a given PCI device
+
+         Name: none
+         Value: 1 if available, 0 otherwise
+
+    - oid: "/agent/hardware/pci/device/eswitch/mode"
+      access: read_write
+      type: string
+      d: |
+         Current eswitch mode
+
+         Name: none
+         Value: eswitch mode ('legacy' or 'switchdev'), empty if not available
+
     - oid: "/agent/hardware/pci/device/param"
       access: read_only
       type: none

--- a/lib/netconf/devlink.c
+++ b/lib/netconf/devlink.c
@@ -170,6 +170,208 @@ netconf_devlink_get_info(netconf_handle nh, const char *bus,
 
 #endif /* HAVE_DECL_DEVLINK_CMD_INFO_GET */
 
+#if HAVE_DECL_DEVLINK_CMD_ESWITCH_GET
+
+/* Convert native configuration mode to netconf constant */
+static netconf_devlink_param_cmode
+devlink_eswitch_mode_h2netconf(uint16_t val)
+{
+#define CHECK_MODE(_name) \
+    case DEVLINK_ESWITCH_MODE_ ## _name:                 \
+        return NETCONF_DEVLINK_ESWITCH_MODE_ ## _name
+
+    switch (val)
+    {
+        CHECK_MODE(LEGACY);
+        CHECK_MODE(SWITCHDEV);
+
+        default:
+            return NETCONF_DEVLINK_ESWITCH_MODE_UNDEF;
+    }
+#undef CHECK_MODE
+}
+
+/* Process attributes of DEVLINK_CMD_ESWITCH_GET message */
+static te_errno
+eswitch_attr_cb(struct nlattr *na, void *cb_data)
+{
+    netconf_devlink_eswitch *eswitch = cb_data;
+    uint16_t res;
+
+    switch (na->nla_type)
+    {
+        case DEVLINK_ATTR_ESWITCH_MODE:
+            netconf_get_uint16_attr(na, &res);
+            eswitch->mode = devlink_eswitch_mode_h2netconf(res);
+            break;
+    }
+
+    return 0;
+}
+
+/* Process device information message received from netlink */
+static int
+eswitch_cb(struct nlmsghdr *h, netconf_list *list, void *cookie)
+{
+    netconf_devlink_eswitch *eswitch;
+    te_errno rc = 0;
+
+    UNUSED(cookie);
+
+    if (netconf_list_extend(list, NETCONF_NODE_DEVLINK_ESWITCH) != 0)
+        return -1;
+
+    eswitch = &(list->tail->data.devlink_eswitch);
+
+    rc = netconf_gn_process_attrs(h, eswitch_attr_cb, eswitch);
+    if (rc != 0)
+        return -1;
+
+    return 0;
+}
+
+/* See description in netconf.h */
+te_errno
+netconf_devlink_get_eswitch(netconf_handle nh, const char *bus,
+                            const char *dev, netconf_list **list)
+{
+    int os_rc;
+    te_errno rc = 0;
+    char req[NETCONF_MAX_REQ_LEN] = { 0, };
+    struct nlmsghdr *h;
+    uint16_t req_flags = NLM_F_REQUEST;
+    netconf_list *list_ptr = NULL;
+
+    if (bus == NULL || dev == NULL)
+    {
+        if (dev != bus)
+        {
+            ERROR("%s(): either specify both bus and dev or none of them",
+                  __FUNCTION__);
+            return TE_EINVAL;
+        }
+
+        req_flags |= NLM_F_DUMP;
+    }
+
+    GET_CHECK_DEVLINK_FAMILY(nh);
+
+    h = (struct nlmsghdr *)req;
+
+    rc = netconf_gn_init_hdrs(req, sizeof(req), devlink_family, req_flags,
+                              DEVLINK_CMD_ESWITCH_GET, DEVLINK_GENL_VERSION,
+                              nh);
+    if (rc != 0)
+        return rc;
+
+    if (bus != NULL)
+    {
+        rc = netconf_append_attr(req, sizeof(req), DEVLINK_ATTR_BUS_NAME,
+                                 bus, strlen(bus) + 1);
+        if (rc != 0)
+            return rc;
+
+        rc = netconf_append_attr(req, sizeof(req), DEVLINK_ATTR_DEV_NAME,
+                                 dev, strlen(dev) + 1);
+        if (rc != 0)
+            return rc;
+    }
+
+    list_ptr = TE_ALLOC(sizeof(*list_ptr));
+    if (list_ptr == NULL)
+        return TE_ENOMEM;
+
+    os_rc = netconf_talk(nh, req, h->nlmsg_len, eswitch_cb, NULL, list_ptr);
+    if (os_rc != 0)
+    {
+        rc = te_rc_os2te(errno);
+        netconf_list_free(list_ptr);
+    }
+    else
+    {
+        *list = list_ptr;
+    }
+
+    return rc;
+}
+
+#endif /* HAVE_DECL_DEVLINK_CMD_ESWITCH_GET */
+
+#if HAVE_DECL_DEVLINK_CMD_ESWITCH_SET
+
+/* Convert native configuration mode from netconf constant */
+static te_errno
+devlink_eswitch_mode_netconf2h(uint8_t mode, uint16_t *val)
+{
+#define CHECK_MODE(_name) \
+    case NETCONF_DEVLINK_ESWITCH_MODE_ ## _name:         \
+        *val = DEVLINK_ESWITCH_MODE_ ## _name;           \
+        break
+
+    switch (mode)
+    {
+        CHECK_MODE(LEGACY);
+        CHECK_MODE(SWITCHDEV);
+
+        default:
+            return TE_ENOENT;
+    }
+
+    return 0;
+#undef CHECK_MODE
+}
+
+/* See description in netconf.h */
+te_errno
+netconf_devlink_eswitch_mode_set(netconf_handle nh, const char *bus,
+                                 const char *dev,
+                                 netconf_devlink_eswitch_mode mode)
+{
+    int os_rc;
+    te_errno rc = 0;
+    char req[NETCONF_MAX_REQ_LEN] = { 0, };
+    struct nlmsghdr *h;
+    uint16_t native_mode;
+
+    GET_CHECK_DEVLINK_FAMILY(nh);
+
+    h = (struct nlmsghdr *)req;
+
+    rc = devlink_eswitch_mode_netconf2h(mode, &native_mode);
+    if (rc != 0)
+        return rc;
+
+    rc = netconf_gn_init_hdrs(req, sizeof(req), devlink_family,
+                              NLM_F_REQUEST | NLM_F_ACK,
+                              DEVLINK_CMD_ESWITCH_SET, DEVLINK_GENL_VERSION,
+                              nh);
+    if (rc != 0)
+        return rc;
+
+    rc = netconf_append_attr(req, sizeof(req), DEVLINK_ATTR_BUS_NAME,
+                             bus, strlen(bus) + 1);
+    if (rc != 0)
+        return rc;
+
+    rc = netconf_append_attr(req, sizeof(req), DEVLINK_ATTR_DEV_NAME,
+                             dev, strlen(dev) + 1);
+    if (rc != 0)
+        return rc;
+
+    rc = netconf_append_attr(req, sizeof(req), DEVLINK_ATTR_ESWITCH_MODE,
+                             &native_mode, sizeof(native_mode));
+    if (rc != 0)
+        return rc;
+
+    os_rc = netconf_talk(nh, req, h->nlmsg_len, NULL, NULL, NULL);
+    if (os_rc != 0)
+        rc = te_rc_os2te(errno);
+
+    return rc;
+}
+
+#endif /* HAVE_DECL_DEVLINK_CMD_ESWITCH_SET */
+
 #if HAVE_DECL_DEVLINK_CMD_PARAM_GET
 
 /*
@@ -797,4 +999,31 @@ netconf_devlink_param_value_data_mv(
 
     memcpy(dst, src, sizeof(*src));
     memset(src, 0, sizeof(*src));
+}
+
+/* See description in netconf.h */
+const char *
+netconf_devlink_eswitch_mode_netconf2str(netconf_devlink_eswitch_mode mode)
+{
+    switch (mode)
+    {
+        case NETCONF_DEVLINK_ESWITCH_MODE_LEGACY:
+            return "legacy";
+        case NETCONF_DEVLINK_ESWITCH_MODE_SWITCHDEV:
+            return "switchdev";
+        default:
+            return "<unknown>";
+    }
+}
+
+/* See description in netconf.h */
+netconf_devlink_eswitch_mode
+netconf_devlink_eswitch_mode_str2netconf(const char *mode)
+{
+    if (strcmp(mode, "legacy") == 0)
+        return NETCONF_DEVLINK_ESWITCH_MODE_LEGACY;
+    else if (strcmp(mode, "switchdev") == 0)
+        return NETCONF_DEVLINK_ESWITCH_MODE_SWITCHDEV;
+
+    return NETCONF_DEVLINK_ESWITCH_MODE_UNDEF;
 }

--- a/lib/netconf/link.c
+++ b/lib/netconf/link.c
@@ -58,6 +58,18 @@ link_list_cb(struct nlmsghdr *h, netconf_list *list, void *cookie)
                 link->ifname = netconf_dup_rta(rta);
                 break;
 
+            case IFLA_PHYS_SWITCH_ID:
+                link->switch_id = netconf_bytes2str_rta(rta);
+                break;
+
+            case IFLA_PHYS_PORT_ID:
+                link->port_id = netconf_bytes2str_rta(rta);
+                break;
+
+            case IFLA_PHYS_PORT_NAME:
+                link->port_name = netconf_dup_rta(rta);
+                break;
+
             case IFLA_LINKINFO:
             {
                 struct rtattr *linkinfo[IFLA_INFO_MAX + 1];
@@ -103,6 +115,8 @@ netconf_link_node_free(netconf_node *node)
     free(node->data.link.broadcast);
     free(node->data.link.ifname);
     free(node->data.link.info_kind);
+    free(node->data.link.switch_id);
+    free(node->data.link.port_name);
 
     free(node);
 }

--- a/lib/netconf/meson.build
+++ b/lib/netconf/meson.build
@@ -62,6 +62,8 @@ if cc.has_header('linux/devlink.h')
     conf_data.set('HAVE_LINUX_DEVLINK_H', 1)
 
     devlink_cmds = [
+        'DEVLINK_CMD_ESWITCH_GET',
+        'DEVLINK_CMD_ESWITCH_SET',
         'DEVLINK_CMD_INFO_GET',
         'DEVLINK_CMD_PARAM_GET',
         'DEVLINK_CMD_PARAM_SET',

--- a/lib/netconf/netconf.c
+++ b/lib/netconf/netconf.c
@@ -248,6 +248,29 @@ netconf_dup_rta(const struct rtattr *rta)
     return data;
 }
 
+void *
+netconf_bytes2str_rta(const struct rtattr *rta)
+{
+    unsigned char     *data;
+    char              *out;
+    unsigned int       i;
+    static const char  hex[] = "0123456789abcdef";
+
+    out = TE_ALLOC(RTA_PAYLOAD(rta) * 2 + 1);
+    if (out == NULL)
+        return out;
+
+    data = RTA_DATA(rta);
+    for (i = 0; i < RTA_PAYLOAD(rta); i++)
+    {
+        out[i * 2]     = hex[(data[i] >> 4) & 0xf];
+        out[i * 2 + 1] = hex[ data[i]       & 0xf];
+    }
+    out[i * 2] = '\0';
+
+    return out;
+}
+
 void
 netconf_list_filter(netconf_list *list,
                     netconf_node_filter_t filter,

--- a/lib/netconf/netconf.h
+++ b/lib/netconf/netconf.h
@@ -383,6 +383,38 @@ typedef struct netconf_devlink_param {
     netconf_devlink_param_value values[NETCONF_DEVLINK_PARAM_CMODES];
 } netconf_devlink_param;
 
+typedef enum netconf_devlink_eswitch_mode {
+    NETCONF_DEVLINK_ESWITCH_MODE_LEGACY,    /**< Legacy eswitch mode */
+    NETCONF_DEVLINK_ESWITCH_MODE_SWITCHDEV, /**< Switchdev eswitch mode */
+    /* This should be the last in enum */
+    NETCONF_DEVLINK_ESWITCH_MODE_UNDEF,     /**< Not defined */
+} netconf_devlink_eswitch_mode;
+
+/** Information about device eswitch obtained from devlink */
+typedef struct netconf_devlink_eswitch {
+    netconf_devlink_eswitch_mode mode;
+} netconf_devlink_eswitch;
+
+/**
+ * Get string name of device eswitch mode.
+ *
+ * @param mode          Eswitch mode.
+ *
+ * @return Pointer to statically allocated string.
+ */
+extern const char *netconf_devlink_eswitch_mode_netconf2str(
+                                            netconf_devlink_eswitch_mode mode);
+
+/**
+ * Parse name of device eswitch mode.
+ *
+ * @param mode          Name to parse.
+ *
+ * @return One of the values from netconf_devlink_eswitch_mode.
+ */
+extern netconf_devlink_eswitch_mode netconf_devlink_eswitch_mode_str2netconf(
+                                            const char *mode);
+
 /** Type of nodes in the list */
 typedef enum netconf_node_type {
     NETCONF_NODE_UNSPEC,                /**< Unspecified */
@@ -404,6 +436,8 @@ typedef enum netconf_node_type {
     NETCONF_NODE_DEVLINK_INFO,          /**< Device information obtained
                                              from devlink */
     NETCONF_NODE_DEVLINK_PARAM,         /**< Device parameters data obtained
+                                             from devlink */
+    NETCONF_NODE_DEVLINK_ESWITCH,       /**< Eswitch information obtained
                                              from devlink */
 } netconf_node_type;
 
@@ -429,6 +463,7 @@ typedef struct netconf_node {
 
         netconf_devlink_info     devlink_info;
         netconf_devlink_param    devlink_param;
+        netconf_devlink_eswitch  devlink_eswitch;
     } data;                             /**< Network data */
     struct netconf_node  *next;         /**< Next node of the list */
     struct netconf_node  *prev;         /**< Previous node of the list */
@@ -1113,6 +1148,42 @@ extern te_errno netconf_devlink_get_info(netconf_handle nh,
                                          const char *bus,
                                          const char *dev,
                                          netconf_list **list);
+
+/**
+ * Get device eswitch information from devlink.
+ *
+ * @note @p bus and @p dev should be either both @c NULL (to retrieve
+ *       information about all devices) or not @c NULL (to retrieve
+ *       information about specific device).
+ *
+ * @param nh        Netconf session handle.
+ * @param bus       Bus name.
+ * @param dev       Device name (PCI address for PCI device).
+ * @param list      Where to save pointer to the list of retrieved
+ *                  device data (caller should release it).
+ *
+ * @return Status code.
+ */
+extern te_errno netconf_devlink_get_eswitch(netconf_handle nh,
+                                            const char *bus,
+                                            const char *dev,
+                                            netconf_list **list);
+
+/**
+ * Set eswitch mode for a device via devlink.
+ *
+ * @param nh        Netconf session handle.
+ * @param bus       Bus name.
+ * @param dev       Device name (PCI address for PCI device).
+ * @param mode      Eswitch mode to set.
+ *
+ * @return Status code.
+ */
+extern te_errno netconf_devlink_eswitch_mode_set(
+                            netconf_handle nh,
+                            const char *bus,
+                            const char *dev,
+                            netconf_devlink_eswitch_mode mode);
 
 /**
  * Get list of supported device parameters from devlink.

--- a/lib/netconf/netconf.h
+++ b/lib/netconf/netconf.h
@@ -130,6 +130,9 @@ typedef struct netconf_link {
     char               *ifname;         /**< Device name as string */
     char               *info_kind;      /**< Value of IFLA_INFO_KIND
                                              attribute */
+    char               *switch_id;      /**< Switch ID (hex) */
+    char               *port_id;        /**< Port ID (hex) */
+    char               *port_name;      /**< Port name */
     uint32_t            mtu;            /**< MTU of the device */
 } netconf_link;
 

--- a/lib/netconf/netconf_internal.h
+++ b/lib/netconf/netconf_internal.h
@@ -255,6 +255,16 @@ extern uint32_t netconf_get_rta_u32(struct rtattr *rta);
  */
 void *netconf_dup_rta(const struct rtattr *rta);
 
+/**
+ * Duplicate data of rtattr, transforming raw bytes into a readable lowercase
+ * hex string.
+ *
+ * @param rta           Routing atribute.
+ *
+ * @return Address of duplicated data, or NULL in case of error.
+ */
+void *netconf_bytes2str_rta(const struct rtattr *rta);
+
 
 /** Generic callback for attribute processing */
 typedef te_errno (*netconf_attr_cb)(struct nlattr *na, void *cb_data);


### PR DESCRIPTION
Some NICs require using the switchdev interface to create representors and identify representor interfaces.

Testing done: tested by running vswitch-ts on a host with such a NIC