### PR TITLE
lib/tapi: include fuller driver info in PCI node description

### DIFF
--- a/lib/tapi/tapi_cfg_net.c
+++ b/lib/tapi/tapi_cfg_net.c
@@ -1470,14 +1470,25 @@ tapi_cfg_net_node_get_pci_info(cfg_net_t *net, cfg_net_node_t *node,
 
     snprintf(pci_info->pci_addr, 16, "%s:%s:%s.%d", domain, bus, slot, fn);
 
-    agent = CFG_OID_GET_INST_NAME(oid, 1);
-    rc = tapi_cfg_pci_get_ta_driver(agent, NET_DRIVER_TYPE_NET,
-                                    &pci_info->ta_driver);
+    rc = cfg_get_string(&pci_info->bound_driver, "%s/driver:", *pci_oids);
     if (rc != 0)
         goto fail_get_driver;
 
+    agent = CFG_OID_GET_INST_NAME(oid, 1);
+    rc = tapi_cfg_pci_get_ta_driver(agent, NET_DRIVER_TYPE_NET,
+                                    &pci_info->net_driver);
+    if (rc != 0)
+        goto fail_get_net_driver;
+
+    rc = tapi_cfg_pci_get_ta_driver(agent, NET_DRIVER_TYPE_DPDK,
+                                    &pci_info->dpdk_driver);
+    if (rc != 0)
+        goto fail_get_dpdk_driver;
+
     return 0;
 
+fail_get_dpdk_driver:
+fail_get_net_driver:
 fail_get_driver:
     tapi_cfg_net_free_pci_info(pci_info);
 fail_get_fn:
@@ -2613,12 +2624,16 @@ void
 tapi_cfg_net_init_pci_info(cfg_net_pci_info_t *pci_info)
 {
     pci_info->pci_addr = NULL;
-    pci_info->ta_driver = NULL;
+    pci_info->bound_driver = NULL;
+    pci_info->dpdk_driver = NULL;
+    pci_info->net_driver = NULL;
 }
 
 void
 tapi_cfg_net_free_pci_info(cfg_net_pci_info_t *pci_info)
 {
     free(pci_info->pci_addr);
-    free(pci_info->ta_driver);
+    free(pci_info->bound_driver);
+    free(pci_info->net_driver);
+    free(pci_info->dpdk_driver);
 }

--- a/lib/tapi/tapi_cfg_net.h
+++ b/lib/tapi/tapi_cfg_net.h
@@ -70,7 +70,9 @@ typedef struct cfg_nets_t {
 typedef struct cfg_net_pci_info_t {
     enum net_node_type  node_type;
     char               *pci_addr;
-    char               *ta_driver;
+    char               *bound_driver;
+    char               *net_driver;
+    char               *dpdk_driver;
 } cfg_net_pci_info_t;
 
 /**


### PR DESCRIPTION
Redefine ta_driver to mean the currently bound driver. Add information about NET and DPDK drivers for easier access from tests.

Breaks: changes the behaviour of tapi_cfg_net_node_get_pci_info and tapi_cfg_net_get_iut_if_pci_info functions.

Testing done: the new version of this function is used in vswitch-ts to easily find the bound driver and pass both net and DPDK driver names to configuration scripts.