### PR TITLE
Support RTE flow INDIRECT action

### DIFF
--- a/lib/ndn/ndn_rte_flow.c
+++ b/lib/ndn/ndn_rte_flow.c
@@ -60,6 +60,7 @@ asn_enum_entry_t _ndn_rte_flow_action_type_enum_entries[] = {
     {"represented-port", NDN_FLOW_ACTION_TYPE_REPRESENTED_PORT},
     {"jump", NDN_FLOW_ACTION_TYPE_JUMP},
     {"dec-ttl", NDN_FLOW_ACTION_TYPE_DEC_TTL},
+    {"indirect", NDN_FLOW_ACTION_TYPE_INDIRECT},
 };
 
 asn_type ndn_rte_flow_action_type_s = {
@@ -207,6 +208,8 @@ static asn_named_entry_t _ndn_rte_flow_action_conf_ne_array[] = {
         {PRIVATE, NDN_FLOW_ACTION_ETHDEV_PORT_ID} },
     { "group", &asn_base_int32_s,
         {PRIVATE, NDN_FLOW_ACTION_GROUP} },
+    { "handle", &asn_base_uint32_s,
+        {PRIVATE, NDN_FLOW_ACTION_HANDLE} },
 };
 
 asn_type ndn_rte_flow_action_conf_s = {

--- a/lib/ndn/ndn_rte_flow.h
+++ b/lib/ndn/ndn_rte_flow.h
@@ -53,6 +53,7 @@ typedef enum {
     NDN_FLOW_ACTION_TYPE_REPRESENTED_PORT,
     NDN_FLOW_ACTION_TYPE_JUMP,
     NDN_FLOW_ACTION_TYPE_DEC_TTL,
+    NDN_FLOW_ACTION_TYPE_INDIRECT,
 } ndn_rte_flow_action_type_t;
 
 typedef enum {
@@ -105,6 +106,7 @@ typedef enum {
     NDN_FLOW_ACTION_OF_SET_VLAN_VID,
     NDN_FLOW_ACTION_ETHDEV_PORT_ID,
     NDN_FLOW_ACTION_GROUP,
+    NDN_FLOW_ACTION_HANDLE,
 } ndn_rte_flow_action_t;
 
 typedef enum {

--- a/lib/rpcc_dpdk/tapi_rpc_rte.h
+++ b/lib/rpcc_dpdk/tapi_rpc_rte.h
@@ -26,6 +26,8 @@ typedef rpc_ptr rpc_rte_flow_attr_p;
 typedef rpc_ptr rpc_rte_flow_item_p;
 typedef rpc_ptr rpc_rte_flow_action_p;
 typedef rpc_ptr rpc_rte_flow_p;
+typedef rpc_ptr rpc_rte_flow_action_handle_p;
+typedef rpc_ptr rpc_rte_flow_action_handle_update_p;
 
 /**
  * Get TE_ENV_DPDK_REUSE_RPCS feature status

--- a/lib/rpcc_dpdk/tapi_rpc_rte_flow.h
+++ b/lib/rpcc_dpdk/tapi_rpc_rte_flow.h
@@ -182,6 +182,71 @@ extern int rpc_rte_flow_tunnel_item_release(
                                      uint32_t                      num_of_items,
                                      struct tarpc_rte_flow_error  *error);
 
+/**
+ * rte_flow_action_handle_create() RPC.
+ *
+ * @param[in]  port_id     Port number.
+ * @param[in]  conf        RTE flow indirect action configuration.
+ * @param[in]  action      Pointer to RTE flow action.
+ * @param[out] error       Perform verbose error reporting if not @c NULL.
+ *
+ * @return RTE flow indirect action handle pointer on success;
+ *.        jumps out when pointer is @c NULL.
+ */
+extern rpc_rte_flow_action_handle_p rpc_rte_flow_action_handle_create(
+                                     rcf_rpc_server *rpcs,
+                                     uint16_t port_id,
+                                     tarpc_rte_flow_indir_action_conf *conf,
+                                     rpc_rte_flow_action_p action,
+                                     struct tarpc_rte_flow_error *error);
+
+/**
+ * rte_flow_action_handle_destroy() RPC.
+ *
+ * @param[in]  port_id     Port number.
+ * @param[in]  handle      Pointer to RTE flow indirect action handle.
+ * @param[out] error       Perform verbose error reporting if not @c NULL.
+ *
+ * @return @c 0 on success; jumps out in case of failure
+ */
+extern int rpc_rte_flow_action_handle_destroy(
+                                     rcf_rpc_server *rpcs,
+                                     uint16_t port_id,
+                                     rpc_rte_flow_action_handle_p handle,
+                                     struct tarpc_rte_flow_error *error);
+
+/**
+ * rte_flow_action_handle_update() RPC.
+ *
+ * @param[in]  port_id     Port number.
+ * @param[in]  handle      Pointer to RTE flow indirect action handle.
+ * @param[in]  update      Pointer to the indirect action object to be updated.
+ * @param[out] error       Perform verbose error reporting if not @c NULL.
+ *
+ * @return @c 0 on success; jumps out in case of failure.
+ */
+extern int rpc_rte_flow_action_handle_update(
+                                     rcf_rpc_server *rpcs, uint16_t port_id,
+                                     rpc_rte_flow_action_handle_p handle,
+                                     rpc_rte_flow_action_handle_update_p update,
+                                     tarpc_rte_flow_error *error);
+
+/**
+ * rte_flow_action_handle_query() RPC.
+ *
+ * @param[in]     port_id  Port number.
+ * @param[in]     handle   Pointer to RTE flow indirect action handle.
+ * @param[in,out] data     Pointer to storage for the associated query data type.
+ * @param[out]    error    Perform verbose error reporting if not @c NULL.
+ *
+ * @return @c 0 on success; jumps out in case of failure.
+ */
+extern int rpc_rte_flow_action_handle_query(
+                                     rcf_rpc_server *rpcs, uint16_t port_id,
+                                     rpc_rte_flow_action_handle_p handle,
+                                     tarpc_rte_flow_query_data *data,
+                                     tarpc_rte_flow_error *error);
+
 /**@} <!-- END te_lib_rpc_rte_flow --> */
 
 #ifdef __cplusplus

--- a/lib/rpcxdr/tarpc_dpdk.x.m4
+++ b/lib/rpcxdr/tarpc_dpdk.x.m4
@@ -24,6 +24,12 @@ typedef tarpc_ptr    tarpc_rte_ring;
 /** Bitmask of RSS hash protocols */
 typedef uint64_t     tarpc_rss_hash_protos_t;
 
+/** Handle of the 'rte_flow_action_handle' or 0 */
+typedef tarpc_ptr    tarpc_rte_flow_action_handle;
+
+/** Handle of the 'rte_flow_action_handle_update' or 0 */
+typedef tarpc_ptr    tarpc_rte_flow_action_handle_update;
+
 /* rte_eal_init() */
 struct tarpc_rte_eal_init_in {
     struct tarpc_in_arg         common;
@@ -2257,6 +2263,75 @@ struct tarpc_rte_flow_release_united_items_in {
 
 typedef struct tarpc_void_out tarpc_rte_flow_release_united_items_out;
 
+struct tarpc_rte_flow_indir_action_conf {
+    tarpc_bool ingress;
+    tarpc_bool egress;
+    tarpc_bool transfer;
+};
+
+/** rte_flow_action_handle_create() */
+struct tarpc_rte_flow_action_handle_create_in {
+    struct tarpc_in_arg              common;
+
+    uint16_t                         port_id;
+    tarpc_rte_flow_indir_action_conf conf;
+    tarpc_rte_flow_action            action;
+};
+
+struct tarpc_rte_flow_action_handle_create_out {
+    struct tarpc_out_arg         common;
+
+    tarpc_rte_flow_action_handle handle;
+    struct tarpc_rte_flow_error  error;
+};
+
+/** rte_flow_action_handle_destroy() */
+struct tarpc_rte_flow_action_handle_destroy_in {
+    struct tarpc_in_arg          common;
+
+    uint16_t                     port_id;
+    tarpc_rte_flow_action_handle handle;
+};
+
+struct tarpc_rte_flow_action_handle_destroy_out {
+    struct tarpc_out_arg        common;
+
+    tarpc_int                   retval;
+    struct tarpc_rte_flow_error error;
+};
+
+/** rte_flow_action_handle_update() */
+struct tarpc_rte_flow_action_handle_update_in {
+    struct tarpc_in_arg                 common;
+
+    uint16_t                            port_id;
+    tarpc_rte_flow_action_handle        handle;
+    tarpc_rte_flow_action_handle_update update;
+};
+
+struct tarpc_rte_flow_action_handle_update_out {
+    struct tarpc_out_arg        common;
+
+    tarpc_int                   retval;
+    struct tarpc_rte_flow_error error;
+};
+
+/** rte_flow_action_handle_query() */
+struct tarpc_rte_flow_action_handle_query_in {
+    struct tarpc_in_arg          common;
+
+    uint16_t                     port_id;
+    tarpc_rte_flow_action_handle handle;
+    tarpc_rte_flow_query_data    data<>;
+};
+
+struct tarpc_rte_flow_action_handle_query_out {
+    struct tarpc_out_arg         common;
+
+    tarpc_rte_flow_query_data    data<>;
+    tarpc_int                    retval;
+    struct tarpc_rte_flow_error  error;
+};
 
 /**
  * Handmade DPDK utility RPCs
@@ -2448,6 +2523,10 @@ program dpdk
         RPC_DEF(rte_flow_release_united_actions)
         RPC_DEF(rte_flow_prepend_opaque_items)
         RPC_DEF(rte_flow_release_united_items)
+        RPC_DEF(rte_flow_action_handle_create)
+        RPC_DEF(rte_flow_action_handle_destroy)
+        RPC_DEF(rte_flow_action_handle_update)
+        RPC_DEF(rte_flow_action_handle_query)
 
         RPC_DEF(dpdk_eth_await_link_up)
         RPC_DEF(dpdk_get_version)

--- a/lib/tapi_dpdk/tapi_rte_flow.c
+++ b/lib/tapi_dpdk/tapi_rte_flow.c
@@ -198,6 +198,21 @@ tapi_rte_flow_add_ndn_action_dec_ttl(asn_value *ndn_actions, int action_index)
 }
 
 void
+tapi_rte_flow_add_ndn_action_indirect(asn_value *ndn_actions,
+                                      int action_index,
+                                      uint32_t handle)
+{
+    asn_value *action;
+
+    CHECK_NOT_NULL(action = asn_init_value(ndn_rte_flow_action));
+    CHECK_RC(asn_write_int32(action, NDN_FLOW_ACTION_TYPE_INDIRECT, "type"));
+    CHECK_RC(asn_write_value_field_fmt(action, &handle, sizeof(handle),
+                                       "conf.#handle"));
+
+    CHECK_RC(asn_insert_indexed(ndn_actions, action, action_index, ""));
+}
+
+void
 tapi_rte_flow_add_ndn_item_port(ndn_rte_flow_item_type_t type,
                                 uint32_t ethdev_port_id,
                                 asn_value *items,

--- a/lib/tapi_dpdk/tapi_rte_flow.h
+++ b/lib/tapi_dpdk/tapi_rte_flow.h
@@ -148,6 +148,17 @@ extern void tapi_rte_flow_add_ndn_action_dec_ttl(asn_value *ndn_actions,
                                                  int action_index);
 
 /**
+ * Add an INDIRECT action to an action list at specified index.
+ *
+ * @param[in,out] ndn_actions       Action list.
+ * @param[in]     action_index      Index at which the action is put to list.
+ * @param[in]     handle            Handle to indirect action.
+ */
+extern void tapi_rte_flow_add_ndn_action_indirect(asn_value *ndn_actions,
+                                                  int action_index,
+                                                  uint32_t handle);
+
+/**
  * Add an item of type PORT_REPRESENTOR / REPRESENTED_PORT to the item list.
  *
  * @param[in]     type            The item type
@@ -209,6 +220,27 @@ extern void tapi_rte_flow_make_attr(rcf_rpc_server *rpcs, uint32_t group,
  */
 extern void tapi_rte_flow_isolate(rcf_rpc_server *rpcs, uint16_t port_id,
                                   int set);
+
+/**
+ * Init indirect action object configuration.
+ *
+ * @param[in]   ingress    Ingress traffic.
+ * @param[in]   egress     Egress traffic.
+ * @param[in]   transfer   Transfer traffic.
+ * @param[out]  conf       Indirect action object configuration.
+ */
+static inline void
+tapi_rte_flow_inidir_action_conf_init(te_bool ingress, te_bool egress,
+                                      te_bool transfer,
+                                      tarpc_rte_flow_indir_action_conf *conf)
+{
+    if (conf != NULL)
+    {
+          conf->ingress = ingress;
+          conf->egress = egress;
+          conf->transfer = transfer;
+    }
+}
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
Tested with a modified version of [flow_rule_drop](https://github.com/Xilinx-CNS/cns-dpdk-pmd-ts/blob/main/ts/filters/flow_rule_drop.c) test by replacing **COUNT** action with **INDIRECT COUNT**.

These changes produce no warning.