### PR TITLE
Support for matching by fragmentation offset field in IPv4 item

### DIFF
--- a/lib/ndn/ndn_rte_flow.c
+++ b/lib/ndn/ndn_rte_flow.c
@@ -303,3 +303,55 @@ asn_type ndn_rte_flow_rule_s = {
 
 const asn_type * const ndn_rte_flow_pattern = &ndn_generic_pdu_sequence_s;
 const asn_type * const ndn_rte_flow_rule = &ndn_rte_flow_rule_s;
+
+te_errno
+ndn_rte_flow_read_with_offset(const asn_value *pdu, const char *name,
+                              size_t size, uint32_t offset, uint32_t *spec_p,
+                              uint32_t *mask_p, uint32_t *last_p)
+{
+    uint32_t val;
+    uint32_t spec_val = 0;
+    uint32_t mask_val = 0;
+    uint32_t last_val = 0;
+    char buf[NDN_RTE_FLOW_FIELD_NAME_MAX_LEN];
+    unsigned int i;
+    int rc;
+
+    snprintf(buf, NDN_RTE_FLOW_FIELD_NAME_MAX_LEN, "%s.#plain", name);
+    rc = asn_read_uint32(pdu, &val, buf);
+    if (rc == 0)
+    {
+        spec_val |= val << offset;
+        for (i = 0; i < size; i++)
+            mask_val |= 1U << (offset + i);
+    }
+    else if (rc == TE_EASNOTHERCHOICE)
+    {
+        snprintf(buf, NDN_RTE_FLOW_FIELD_NAME_MAX_LEN, "%s.#range.first", name);
+        rc = asn_read_uint32(pdu, &val, buf);
+        if (rc == 0)
+            spec_val |= val << offset;
+        if (rc == 0 || rc == TE_EASNINCOMPLVAL)
+        {
+            snprintf(buf, NDN_RTE_FLOW_FIELD_NAME_MAX_LEN, "%s.#range.last", name);
+            rc = asn_read_uint32(pdu, &val, buf);
+        }
+        if (rc == 0)
+            last_val |= val << offset;
+        if (rc == 0 || rc == TE_EASNINCOMPLVAL)
+        {
+            snprintf(buf, NDN_RTE_FLOW_FIELD_NAME_MAX_LEN, "%s.#range.mask", name);
+            rc = asn_read_uint32(pdu, &val, buf);
+        }
+        if (rc == 0)
+            mask_val |= val << offset;
+    }
+    if (rc != 0 && rc != TE_EASNINCOMPLVAL && rc != TE_EASNOTHERCHOICE)
+        return rc;
+
+    *spec_p |= spec_val;
+    *mask_p |= mask_val;
+    *last_p |= last_val;
+
+    return 0;
+}

--- a/lib/ndn/ndn_rte_flow.h
+++ b/lib/ndn/ndn_rte_flow.h
@@ -136,6 +136,29 @@ extern const asn_type * const ndn_rte_flow_item_conf;
 
 extern asn_type ndn_rte_flow_rule_s;
 
+#define NDN_RTE_FLOW_FIELD_NAME_MAX_LEN 128
+
+/**
+ * Get values of spec, mask and last of requested field with specified name
+ * based on size of the value (in bits) and offset of the value (in bits)
+ *
+ * @param pdu    ASN.1 value
+ * @param name   Name of the field
+ * @param size   Size of the requested filed
+ * @param offset Offset of the requested filed
+ * @param spec_p Pointer to the spec
+ * @param mask_p Pointer to the mask
+ * @param last_p Pointer to the last
+ *
+ * @return Status code
+*/
+extern te_errno ndn_rte_flow_read_with_offset(const asn_value *pdu,
+                                              const char *name,
+                                              size_t size, uint32_t offset,
+                                              uint32_t *spec_p,
+                                              uint32_t *mask_p,
+                                              uint32_t *last_p);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/lib/ndn/ndn_rte_flow.h
+++ b/lib/ndn/ndn_rte_flow.h
@@ -137,6 +137,11 @@ extern const asn_type * const ndn_rte_flow_item_conf;
 extern asn_type ndn_rte_flow_rule_s;
 
 #define NDN_RTE_FLOW_FIELD_NAME_MAX_LEN 128
+#define NDN_RTE_FLOW_IPV4_FRAG_OFST_FIELD_LEN 13
+#define NDN_RTE_FLOW_IPV4_FRAG_OFST_FIELD_OFFSET 0
+#define NDN_RTE_FLOW_IPV4_FLAG_FIELD_LEN 1
+#define NDN_RTE_FLOW_IPV4_FLAG_MORE_FRAG_FIELD_OFST 13
+#define NDN_RTE_FLOW_IPV4_FLAG_DONT_FRAG_FIELD_OFST 14
 
 /**
  * Get values of spec, mask and last of requested field with specified name


### PR DESCRIPTION
Tested with the filters/flow_rule_ip_frag test. This test has not been added to the [cns-dpdk-pmd-ts](https://github.com/Xilinx-CNS/cns-dpdk-pmd-ts) repository yet 