### PR TITLE
lib/rpcs_dpdk: check for separated DPDK logging library

### DIFF
--- a/lib/rpcs_dpdk/meson.build
+++ b/lib/rpcs_dpdk/meson.build
@@ -159,11 +159,20 @@ if cc.has_function(f, args: te_cflags,
     c_args += [ '-DHAVE_' + f.to_upper() ]
 endif
 
+link_libs = [ '-lrte_ethdev', '-lrte_telemetry', '-lrte_meter',
+              '-lrte_net', '-lrte_mbuf', '-lrte_mempool',
+              '-lrte_ring', '-lrte_kvargs', '-lrte_eal' ]
+
+# Check if the rte_log library exists
+f = 'rte_log'
+has_rte_log = cc.has_function(f, args: te_cflags + te_ldflags + ['-lrte_log'],
+                              prefix: '#include "rte_log.h"')
+if has_rte_log
+    link_libs += [ '-lrte_log' ]
+endif
+
 f = 'rte_flow_isolate'
-if cc.has_function(f, args: te_cflags + te_ldflags +
-                   [ '-lrte_ethdev', '-lrte_telemetry', '-lrte_meter',
-                     '-lrte_net', '-lrte_mbuf', '-lrte_mempool',
-                     '-lrte_ring', '-lrte_kvargs', '-lrte_eal' ],
+if cc.has_function(f, args: te_cflags + te_ldflags + link_libs,
                    prefix: '#include "rte_flow.h"')
     c_args += [ '-DHAVE_' + f.to_upper() ]
 endif


### PR DESCRIPTION
I am not a big Meson expert, so I will be glad to any suggestions for improvement.
DPDK commit in dpdk-next-net repo that changed behaviour:
```
commit 09ce41310930ef73b4c900270de69286e13ff2e8
Author: Bruce Richardson <bruce.richardson@intel.com>
Date:   Wed Aug 9 14:35:52 2023 +0100

log: separate logging functions out of EAL
```


Testing done:
```
rte_flow_isolate() is successfully detected with and without the commit above.
```