### PR TITLE
lib/rpcxdr: implement new RPC function rpc_epoll_pwait2()

### DIFF
--- a/lib/rpc_types/te_rpc_sys_poll.h
+++ b/lib/rpc_types/te_rpc_sys_poll.h
@@ -98,6 +98,8 @@ iomux2str(iomux_func iomux)
             return "epoll";
         case FUNC_EPOLL_PWAIT:
             return "epoll_pwait";
+        case FUNC_EPOLL_PWAIT2:
+            return "epoll_pwait2";
         case FUNC_DEFAULT_IOMUX:
             return "default iomux";
         case FUNC_NO_IOMUX:
@@ -132,6 +134,8 @@ str2iomux(const char *iomux)
         return FUNC_EPOLL;
     else if (strcmp(iomux, "epoll_pwait") == 0)
         return FUNC_EPOLL_PWAIT;
+    else if (strcmp(iomux, "epoll_pwait2") == 0)
+        return FUNC_EPOLL_PWAIT2;
     else
         return 0;
 }

--- a/lib/rpcserver/iomux.h
+++ b/lib/rpcserver/iomux.h
@@ -214,8 +214,11 @@ static inline void
 iomux_state_init_invalid(iomux_func iomux, iomux_state *state)
 {
 #if HAVE_STRUCT_EPOLL_EVENT
-    if (iomux == FUNC_EPOLL || iomux == FUNC_EPOLL_PWAIT)
+    if (iomux == FUNC_EPOLL || iomux == FUNC_EPOLL_PWAIT ||
+        iomux == FUNC_EPOLL_PWAIT2)
+    {
         state->epoll = -1;
+    }
 #endif
 }
 

--- a/lib/rpcxdr/tarpc_base.x.m4
+++ b/lib/rpcxdr/tarpc_base.x.m4
@@ -2974,6 +2974,28 @@ struct tarpc_epoll_pwait_out {
     struct tarpc_epoll_event events<>;
 };
 
+/* epoll_pwait2() */
+
+struct tarpc_epoll_pwait2_in {
+    struct tarpc_in_arg common;
+
+    tarpc_int                epfd;
+    struct tarpc_epoll_event events<>;
+    tarpc_int                maxevents;
+    struct tarpc_timespec    timeout<>;
+    tarpc_sigset_t           sigmask;
+};
+
+struct tarpc_epoll_pwait2_out {
+    struct tarpc_out_arg    common;
+
+    tarpc_int               retval;
+
+    struct tarpc_epoll_event events<>;
+
+    struct tarpc_timespec   timeout<>;
+};
+
 /*
  * Socket options
  */
@@ -4419,8 +4441,9 @@ enum iomux_func {
     FUNC_EPOLL = 5,
     FUNC_EPOLL_PWAIT = 6,
     /** Value 7 is reserved */
-    FUNC_DEFAULT_IOMUX = 8,
-    FUNC_NO_IOMUX = 9
+    FUNC_EPOLL_PWAIT2 = 8,
+    FUNC_DEFAULT_IOMUX = 9,
+    FUNC_NO_IOMUX = 10
 };
 
 
@@ -5659,6 +5682,7 @@ program tarpc
         RPC_DEF(epoll_ctl)
         RPC_DEF(epoll_wait)
         RPC_DEF(epoll_pwait)
+        RPC_DEF(epoll_pwait2)
 
         RPC_DEF(iomux_create_state)
         RPC_DEF(multiple_iomux_wait)

--- a/lib/tapi_rpc/tapi_iomux.h
+++ b/lib/tapi_rpc/tapi_iomux.h
@@ -41,26 +41,28 @@ typedef enum {
     TAPI_IOMUX_EPOLL            = 5,
     TAPI_IOMUX_EPOLL_PWAIT      = 6,
     TAPI_IOMUX_RESERVED         = 7,
-    TAPI_IOMUX_DEFAULT          = 8,
+    TAPI_IOMUX_EPOLL_PWAIT2     = 8,
+    TAPI_IOMUX_DEFAULT          = 9,
 } tapi_iomux_type;
 
 /** Minimum supported iomux type value.  */
 #define TAPI_IOMUX_MIN TAPI_IOMUX_SELECT
 
 /** Maximum supported iomux type value.  */
-#define TAPI_IOMUX_MAX TAPI_IOMUX_EPOLL_PWAIT
+#define TAPI_IOMUX_MAX TAPI_IOMUX_EPOLL_PWAIT2
 
 /**
  * The list of values allowed for test parameter
  * defining iomux function.
  */
 #define TAPI_IOMUX_MAPPING_LIST \
-    { "select",      TAPI_IOMUX_SELECT },      \
-    { "pselect",     TAPI_IOMUX_PSELECT },     \
-    { "poll",        TAPI_IOMUX_POLL },        \
-    { "ppoll",       TAPI_IOMUX_PPOLL },       \
-    { "epoll",       TAPI_IOMUX_EPOLL },       \
-    { "epoll_pwait", TAPI_IOMUX_EPOLL_PWAIT }
+    { "select",           TAPI_IOMUX_SELECT },      \
+    { "pselect",          TAPI_IOMUX_PSELECT },     \
+    { "poll",             TAPI_IOMUX_POLL },        \
+    { "ppoll",            TAPI_IOMUX_PPOLL },       \
+    { "epoll",            TAPI_IOMUX_EPOLL },       \
+    { "epoll_pwait",      TAPI_IOMUX_EPOLL_PWAIT }, \
+    { "epoll_pwait2",     TAPI_IOMUX_EPOLL_PWAIT2 }
 
 /**
  * Get the value of parameter defining iomux function.
@@ -375,8 +377,9 @@ extern void tapi_iomux_del(tapi_iomux_handle *iomux, int fd);
  * Specify a signal mask for a multiplexer.
  *
  * @note This call makes sense for iomux types @c TAPI_IOMUX_PSELECT,
- *       @c TAPI_IOMUX_PPOLL and @c TAPI_IOMUX_EPOLL_PWAIT, the signal mask
- *       is ignored by other muxers.
+ *       @c TAPI_IOMUX_PPOLL, @c TAPI_IOMUX_EPOLL_PWAIT and
+ *       @c TAPI_IOMUX_EPOLL_PWAIT2, the signal mask is ignored by other
+ *       muxers.
  *
  * @param iomux     The multiplexer handle.
  * @param sigmask   RPC pointer to the signal mask.
@@ -429,8 +432,8 @@ extern int tapi_iomux_pcall(tapi_iomux_handle *iomux, int timeout,
 extern void tapi_iomux_destroy(tapi_iomux_handle *iomux);
 
 /**
- * Process returned events by @c epoll_wait() or @c epoll_pwait() call,
- * convert and save them in the iomux context.
+ * Process returned events by @c epoll_wait(), @c epoll_pwait() or
+ * @c epoll_pwait2() call, convert and save them in the iomux context.
  *
  * @param iomux     The multiplexer handle.
  * @param events    Returned epoll events array.

--- a/lib/tapi_rpc/tapi_rpc_unistd.h
+++ b/lib/tapi_rpc/tapi_rpc_unistd.h
@@ -779,6 +779,18 @@ rpc_epoll_pwait(rcf_rpc_server *rpcs, int epfd,
     return rpc_epoll_pwait_gen(rpcs, epfd, events, maxevents, maxevents,
                                timeout, sigmask);
 }
+extern int rpc_epoll_pwait2_gen(rcf_rpc_server *rpcs, int epfd,
+                                struct rpc_epoll_event *events, int rmaxev,
+                                int maxevents, struct tarpc_timespec *timeout,
+                                const rpc_sigset_p sigmask);
+static inline int
+rpc_epoll_pwait2(rcf_rpc_server *rpcs, int epfd, struct rpc_epoll_event *events,
+                 int maxevents, struct tarpc_timespec *timeout,
+                 const rpc_sigset_p sigmask)
+{
+    return rpc_epoll_pwait2_gen(rpcs, epfd, events, maxevents, maxevents,
+                                    timeout, sigmask);
+}
 
 /**
  * Provide a generic mechanism for reporting I/O conditions associated with


### PR DESCRIPTION
The function epoll_pwait2() was added in Linux 5.11. Add the corresponding
RPC function to TE. It is similar to rpc_epoll_pwait(), except for type of
the argument 'timeout'.

Signed-off-by: Boris Shleyfman <bshleyfman@oktet.co.il>
Reviewed-by: Yurij Plotnikov <yurij.plotnikov@arknetworks.am>