### PR TITLE
lib/rpc_dpdk: add RPC for transfer proxy pick API

### DIFF
--- a/lib/rpcc_dpdk/rte_flow_ndn.c
+++ b/lib/rpcc_dpdk/rte_flow_ndn.c
@@ -842,3 +842,36 @@ rpc_rte_flow_release_united_items(rcf_rpc_server       *rpcs,
 
     RETVAL_VOID(rte_flow_release_united_items);
 }
+
+int
+rpc_rte_flow_pick_transfer_proxy(rcf_rpc_server *rpcs, uint16_t port_id,
+                                 uint16_t *proxy_port_id,
+                                 tarpc_rte_flow_error *error)
+{
+    tarpc_rte_flow_pick_transfer_proxy_in   in = {};
+    tarpc_rte_flow_pick_transfer_proxy_out  out = {};
+    te_log_buf                             *tlbp;
+
+    TAPI_RPC_SET_IN_ARG_IF_PTR_NOT_NULL(proxy_port_id);
+
+    in.port_id = port_id;
+
+    rcf_rpc_call(rpcs, "rte_flow_pick_transfer_proxy", &in, &out);
+
+    TAPI_RPC_CHECK_OUT_ARG_SINGLE_PTR(rte_flow_pick_transfer_proxy, proxy_port_id);
+
+    CHECK_RETVAL_VAR_IS_ZERO_OR_NEG_ERRNO(rte_flow_pick_transfer_proxy, out.retval);
+
+    tlbp = te_log_buf_alloc();
+    TAPI_RPC_LOG(rpcs, rte_flow_pick_transfer_proxy,
+                 "port_id=%" PRIu16, "%s: %s", in.port_id,
+                 NEG_ERRNO_ARGS(out.retval), (out.error.type != 0) ?
+                 tarpc_rte_flow_error2str(tlbp, &out.error) : "");
+    te_log_buf_free(tlbp);
+
+    TAPI_RPC_COPY_OUT_ARG_IF_PTR_NOT_NULL(proxy_port_id);
+
+    tarpc_rte_flow_error_copy(error, &out.error);
+
+    RETVAL_ZERO_INT(rte_flow_pick_transfer_proxy, out.retval);
+}

--- a/lib/rpcc_dpdk/tapi_rpc_rte_flow.h
+++ b/lib/rpcc_dpdk/tapi_rpc_rte_flow.h
@@ -182,6 +182,20 @@ extern int rpc_rte_flow_tunnel_item_release(
                                      uint32_t                      num_of_items,
                                      struct tarpc_rte_flow_error  *error);
 
+/**
+ * rte_flow_pick_transfer_proxy() RPC.
+ *
+ * @param[in]     port_id           Port number.
+ * @param[out]    proxy_port_id     Proxy port id number.
+ * @param[out]    error             Perform verbose error reporting if not @c NULL.
+ *
+ * @return @c 0 on success; jumps out in case of failure.
+ */
+extern int rpc_rte_flow_pick_transfer_proxy(
+                                     rcf_rpc_server *rpcs, uint16_t port_id,
+                                     uint16_t *proxy_port_id,
+                                     tarpc_rte_flow_error *error);
+
 /**@} <!-- END te_lib_rpc_rte_flow --> */
 
 #ifdef __cplusplus

--- a/lib/rpcs_dpdk/rte_flow_ndn.c
+++ b/lib/rpcs_dpdk/rte_flow_ndn.c
@@ -3206,6 +3206,28 @@ TARPC_FUNC(rte_flow_tunnel_item_release, {},
     neg_errno_h2rpc(&out->retval);
 })
 
+TARPC_FUNC(rte_flow_pick_transfer_proxy,
+{
+    COPY_ARG(proxy_port_id);
+},
+{
+    uint16_t              *proxy_port_idp = NULL;
+    struct rte_flow_error  error = {};
+
+    CHECK_ARG_SINGLE_PTR(out, proxy_port_id);
+
+    if (out->proxy_port_id.proxy_port_id_len != 0)
+        proxy_port_idp = out->proxy_port_id.proxy_port_id_val;
+
+    MAKE_CALL(out->retval = func(in->port_id, proxy_port_idp, &error));
+
+    neg_errno_h2rpc(&out->retval);
+
+    tarpc_rte_error2tarpc(&out->error, &error);
+done:
+    ;
+})
+
 TARPC_FUNC_STANDALONE(rte_flow_prepend_opaque_actions, {},
 {
     unsigned int             nb_united_actions;

--- a/lib/rpcxdr/tarpc_dpdk.x.m4
+++ b/lib/rpcxdr/tarpc_dpdk.x.m4
@@ -2258,6 +2258,22 @@ struct tarpc_rte_flow_release_united_items_in {
 typedef struct tarpc_void_out tarpc_rte_flow_release_united_items_out;
 
 
+/** rte_flow_pick_transfer_proxy() */
+struct tarpc_rte_flow_pick_transfer_proxy_in {
+    struct tarpc_in_arg          common;
+
+    uint16_t                     port_id;
+    uint16_t                     proxy_port_id<>;
+};
+
+struct tarpc_rte_flow_pick_transfer_proxy_out {
+    struct tarpc_out_arg         common;
+
+    tarpc_int                    retval;
+    uint16_t                     proxy_port_id<>;
+    struct tarpc_rte_flow_error  error;
+};
+
 /**
  * Handmade DPDK utility RPCs
  */
@@ -2464,6 +2480,7 @@ program dpdk
         RPC_DEF(rte_flow_release_united_actions)
         RPC_DEF(rte_flow_prepend_opaque_items)
         RPC_DEF(rte_flow_release_united_items)
+        RPC_DEF(rte_flow_pick_transfer_proxy)
 
         RPC_DEF(dpdk_eth_await_link_up)
         RPC_DEF(dpdk_get_version)


### PR DESCRIPTION
Allow tests to find the proxy port that should be used when managing transfer flows for a given port.

Useful for representors testing.

Testing done: tested manually and with a modified version of dpdk-ethdev-ts/representors/ovs_decap_hw_offload