### PR TITLE
engine/logger: avoid repeating output in tee

### DIFF
--- a/engine/logger/te_tee.c
+++ b/engine/logger/te_tee.c
@@ -239,7 +239,7 @@ main (int argc, char *argv[])
                 break;
             }
 
-            te_string_append(&buffer_str, "%s", buffer);
+            te_string_append_buf(&buffer_str, buffer, len);
             te_string_process_lines(&buffer_str, TRUE, line_handler, &cur_msg);
 
             if (current_timeout < 0)


### PR DESCRIPTION
Limit the size of data appended to the "buffer string" by the length of the data chunk actually read from the child process to avoid various memory-related errors. The most common is repeating output because of the lack of null terminator in the original buffer.

Fixes: 1755a582f069 ("engine/logger: use new method to parse logs in TE tee")

Testing done: tested manually with dpdk-ethdev-ts, EAL logs no longer contain "leftovers" from previous reads