### PR TITLE
doc/cm: mark eswitch objects volatile

### DIFF
--- a/doc/cm/cm_base.yml
+++ b/doc/cm/cm_base.yml
@@ -105,18 +105,21 @@
     - oid: "/agent/interface/switch_id"
       access: read_only
       type: string
+      volatile: true
       d: |
         Switchdev switch ID
 
     - oid: "/agent/interface/port_id"
       access: read_only
       type: string
+      volatile: true
       d: |
         Switchdev port ID
 
     - oid: "/agent/interface/port_name"
       access: read_only
       type: string
+      volatile: true
       d: |
         Switchdev port name
 


### PR DESCRIPTION
The values of these objects are very much driver-specific and can change at almost any point. For example, with some drivers, changing the MAC address of a given interface can lead to a change in its port ID.

This driver-specific nature makes it hard to predict all factors that affect the values of these objects. Therefore, to avoid guessing, these objects can be considered volatile.

Testing done: this patch helped prevent configurator rollback errors after MAC change on some configurations