### PR TITLE
lib: add nexthop-mtu to ICMP4

### DIFF
--- a/lib/ndn/ndn_ipstack.c
+++ b/lib/ndn/ndn_ipstack.c
@@ -440,6 +440,8 @@ static asn_named_entry_t _ndn_icmp4_message_ne_array [] = {
       { PRIVATE, NDN_TAG_ICMP4_RX_TS } },
     { "tx-ts",          &ndn_data_unit_int32_s,
       { PRIVATE, NDN_TAG_ICMP4_TX_TS } },
+    { "nexthop-mtu",    &ndn_data_unit_int16_s,
+      { PRIVATE, NDN_TAG_ICMP4_NH_MTU } },
 };
 
 asn_type ndn_icmp4_message_s = {

--- a/lib/ndn/ndn_ipstack.h
+++ b/lib/ndn/ndn_ipstack.h
@@ -115,6 +115,7 @@ typedef enum {
     NDN_TAG_ICMP4_ORIG_TS,
     NDN_TAG_ICMP4_RX_TS,
     NDN_TAG_ICMP4_TX_TS,
+    NDN_TAG_ICMP4_NH_MTU,
 } ndn_icmp4_tags_t;
 
 typedef enum {


### PR DESCRIPTION
The Next-Hop MTU field exists in the Destination
Unreachable message of ICMPv4, so it should also
be added to the ICMPv4 CSAP to enable setting it
in packets via ASN representation.

AMD-Jira-Id: ST-2738
Signed-off-by: Yurij Plotnikov <yurij.plotnikov@arknetworks.am>
Reviewed-by: Denis Pryazhennikov <denis.pryazhennikov@arknetworks.am>