### PR TITLE
lib/tad/ipstack: fix initialization of nexthop-mtu field

### DIFF
--- a/lib/tad/ipstack/tad_icmp4_layer.c
+++ b/lib/tad/ipstack/tad_icmp4_layer.c
@@ -153,7 +153,7 @@ static const tad_bps_pkt_frag tad_icmp4_du_bps_hdr[] =
 {
     { "unused",   16, BPS_FLD_CONST_DEF(NDN_TAG_ICMP4_UNUSED, 0),
       TAD_DU_I32, FALSE },
-    { "nexthop-mtu", 16, BPS_FLD_NO_DEF(NDN_TAG_ICMP4_NH_MTU),
+    { "nexthop-mtu", 16, BPS_FLD_CONST_DEF(NDN_TAG_ICMP4_NH_MTU, 0),
       TAD_DU_I32, FALSE },
 };
 


### PR DESCRIPTION
Set nexthop-mtu to 0 by default, to prevent problems when this field is not initialized in tests.

AMD-Jira-Id: ST-2738
Signed-off-by: Yurij Plotnikov <yurij.plotnikov@arknetworks.am>
Reviewed-by: Denis Pryazhennikov <denis.pryazhennikov@arknetworks.am>