### PR TITLE
lib/tapi_gtest: improve job options handling

### DIFF
--- a/lib/tapi_gtest/tapi_gtest.c
+++ b/lib/tapi_gtest/tapi_gtest.c
@@ -24,11 +24,16 @@ gtest_build_argv(tapi_gtest *gtest, te_vec *argv)
     const tapi_job_opt_bind opts_binds[] = TAPI_JOB_OPT_SET(
         TAPI_JOB_OPT_STRING("--gtest_filter=", TRUE, tapi_gtest_opts,
                             gtest_filter),
+        TAPI_JOB_OPT_STRING("--device_name=", TRUE, tapi_gtest_opts,
+                            dev_name),
         TAPI_JOB_OPT_BOOL("--gtest_also_run_disabled_tests", tapi_gtest_opts,
                           run_disabled),
+        TAPI_JOB_OPT_BOOL("--ipv4_only", tapi_gtest_opts, ipv4_only),
         TAPI_JOB_OPT_BOOL("--gtest_color=no", tapi_gtest_opts, no_col),
         TAPI_JOB_OPT_UINT_T("--gtest_random_seed=", TRUE, NULL,
                             tapi_gtest_opts, rand_seed),
+        TAPI_JOB_OPT_UINT_T("--verbs_mtu=", TRUE, NULL,
+                            tapi_gtest_opts, verbs_mtu)
     );
 
     rc = tapi_job_opt_build_args(gtest->bin, opts_binds, opts, argv);

--- a/lib/tapi_gtest/tapi_gtest.h
+++ b/lib/tapi_gtest/tapi_gtest.h
@@ -15,6 +15,7 @@
 #define __TAPI_GTEST_H__
 
 #include "tapi_job.h"
+#include "tapi_job_opt.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -33,37 +34,44 @@ typedef struct tapi_gtest_impl {
     .out = {0},                                     \
 }
 
+typedef struct tapi_gtest_opts {
+    const char *gtest_filter;      /**< Concatenaion of Group and Test names */
+    te_bool run_disabled;          /**< Force run disabled test */
+    te_bool no_col;                /**< Disable colours in GTest output */
+    tapi_job_opt_uint_t rand_seed; /**< Random seed */
+} tapi_gtest_opts;
+
 /** GTest handler */
 typedef struct tapi_gtest {
     const char *bin;        /**< Path to GTest binary */
     const char *group;      /**< Group name in GTest */
     const char *name;       /**< Test name in GTest */
-
-    bool run_disabled;   /**< Force run disabled test */
-    int rand_seed;          /**< Random seed */
+    tapi_gtest_opts opts;   /**< Options for Gtest binary */
 
     tapi_gtest_impl impl;   /**< Internal implementation struct */
 } tapi_gtest;
 
 /** Defaults for implementation for GTest handler */
-#define TAPI_GTEST_DEFAULTS (tapi_gtest)    \
-{                                           \
-    .bin = NULL,                            \
-    .group = NULL,                          \
-    .name = NULL,                           \
-    .run_disabled = false,                  \
-    .impl = TAPI_GTEST_IMPL_DEFAULTS,       \
+#define TAPI_GTEST_DEFAULTS (tapi_gtest)       \
+{                                              \
+    .bin = NULL,                               \
+    .group = NULL,                             \
+    .name = NULL,                              \
+    .opts.run_disabled = FALSE,                \
+    .opts.no_col = TRUE,                       \
+    .opts.rand_seed = TAPI_JOB_OPT_UINT_UNDEF, \
+    .impl = TAPI_GTEST_IMPL_DEFAULTS,          \
 }
 
 /** A way for read gtest option from test arguments */
-#define TEST_GTEST_PARAM(_gtest) (tapi_gtest)    \
-{                                               \
-    .bin = TEST_STRING_PARAM(_gtest##_bin),      \
-    .group = TEST_STRING_PARAM(_gtest##_group),  \
-    .name = TEST_STRING_PARAM(_gtest##_name),    \
-    .rand_seed = TEST_INT_PARAM(te_rand_seed),  \
-    .run_disabled = false,                      \
-    .impl = TAPI_GTEST_IMPL_DEFAULTS,           \
+#define TEST_GTEST_PARAM(_gtest) (tapi_gtest)                             \
+{                                                                         \
+    .bin = TEST_STRING_PARAM(_gtest##_bin),                               \
+    .group = TEST_STRING_PARAM(_gtest##_group),                           \
+    .name = TEST_STRING_PARAM(_gtest##_name),                             \
+    .opts.rand_seed = TE_OPTIONAL_UINT_VAL(TEST_INT_PARAM(te_rand_seed)), \
+    .opts.run_disabled = FALSE,                                           \
+    .impl = TAPI_GTEST_IMPL_DEFAULTS,                                     \
 }
 
 /** A way for read gtest option from test arguments */

--- a/lib/tapi_gtest/tapi_gtest.h
+++ b/lib/tapi_gtest/tapi_gtest.h
@@ -37,8 +37,12 @@ typedef struct tapi_gtest_impl {
 typedef struct tapi_gtest_opts {
     const char *gtest_filter;      /**< Concatenaion of Group and Test names */
     te_bool run_disabled;          /**< Force run disabled test */
+    te_bool ipv4_only;             /**< Force use of IPv4 */
     te_bool no_col;                /**< Disable colours in GTest output */
     tapi_job_opt_uint_t rand_seed; /**< Random seed */
+
+    const char *dev_name;          /**< RDMA device name for GTest */
+    tapi_job_opt_uint_t verbs_mtu; /**< MTU for RDMA QP */
 } tapi_gtest_opts;
 
 /** GTest handler */
@@ -57,8 +61,11 @@ typedef struct tapi_gtest {
     .bin = NULL,                               \
     .group = NULL,                             \
     .name = NULL,                              \
+    .opts.dev_name = NULL,                     \
     .opts.run_disabled = FALSE,                \
+    .opts.ipv4_only = FALSE,                   \
     .opts.no_col = TRUE,                       \
+    .opts.verbs_mtu = TAPI_JOB_OPT_UINT_UNDEF, \
     .opts.rand_seed = TAPI_JOB_OPT_UINT_UNDEF, \
     .impl = TAPI_GTEST_IMPL_DEFAULTS,          \
 }
@@ -69,8 +76,12 @@ typedef struct tapi_gtest {
     .bin = TEST_STRING_PARAM(_gtest##_bin),                               \
     .group = TEST_STRING_PARAM(_gtest##_group),                           \
     .name = TEST_STRING_PARAM(_gtest##_name),                             \
+    .opts.verbs_mtu = TAPI_JOB_OPT_UINT_UNDEF,                            \
     .opts.rand_seed = TE_OPTIONAL_UINT_VAL(TEST_INT_PARAM(te_rand_seed)), \
+    .opts.ipv4_only = FALSE,                                              \
     .opts.run_disabled = FALSE,                                           \
+    .opts.no_col = TRUE,                                                  \
+    .opts.dev_name = NULL,                                                \
     .impl = TAPI_GTEST_IMPL_DEFAULTS,                                     \
 }
 


### PR DESCRIPTION
Update tapi_gtest_init() function and tapi_gtest structure to handle more options for Gtest.

Signed-off-by: Yurij Plotnikov <yurij.plotnikov@arknetworks.am>
Reviewed-by: Konstantin Ushakov <kushakov@oktet.co.il>
Reviewed-by: Denis Pryazhennikov <denis.pryazhennikov@arknetworks.am>