### PR TITLE
tools/rgt-pdml2xml: clear user context before parsing

### DIFF
--- a/tools/rgt/rgt-pdml2xml/pdml2xml.c
+++ b/tools/rgt/rgt-pdml2xml/pdml2xml.c
@@ -612,6 +612,7 @@ rgt_parse_input_stream(void)
     char             chunk[RGT_CHUNK_SIZE + 1];
 
     memset(chunk, 0, RGT_CHUNK_SIZE + 1);
+    memset(&user_ctx, 0, sizeof(user_ctx));
     user_ctx.state = RGT_LOG_STATE_BASE;
 
     res = read(0, chunk, 4);
@@ -642,6 +643,7 @@ rgt_parse_pdml_file(const char *fname)
     xmlParserCtxtPtr xml_ctxt;
     rgt_user_ctx     user_ctx;
 
+    memset(&user_ctx, 0, sizeof(user_ctx));
     user_ctx.state = RGT_LOG_STATE_BASE;
 
     xml_ctxt = xmlCreateFileParserCtxt(fname);


### PR DESCRIPTION
Prevent garbage values in the output if the given pcap does not include an info packet.

Testing done: Manual testing, not getting segfauls anymore when using a pcap that's not been created by a TE sniffer