### PR TITLE
agents/unix: allow netconsole over routed networks

### DIFF
--- a/lib/netconf/netconf.h
+++ b/lib/netconf/netconf.h
@@ -627,13 +627,15 @@ netconf_list *netconf_route_get_entry_for_addr(netconf_handle nh,
  * @param dst_addr     Destination address
  * @param src_addr     Source address (OUT)
  * @param ifname       Source interface. Must be at least IF_NAMESIZE. (OUT)
+ * @param gateway      Gateway address. (OUT)
  *
  * @return Status code
  */
 int netconf_route_get_src_addr_and_iface(netconf_handle         nh,
                                          const struct sockaddr  *dst_addr,
                                          const struct sockaddr  *src_addr,
-                                         char                   *ifname);
+                                         char                   *ifname,
+                                         struct sockaddr        *gateway);
 
 /**
  * Set default values to fields in rule struct.

--- a/lib/netconf/route.c
+++ b/lib/netconf/route.c
@@ -599,7 +599,8 @@ int
 netconf_route_get_src_addr_and_iface(netconf_handle         nh,
                                      const struct sockaddr  *dst_addr,
                                      const struct sockaddr  *src_addr,
-                                     char                   *ifname)
+                                     char                   *ifname,
+                                     struct sockaddr        *gateway)
 {
     netconf_list    *l;
     netconf_route   *route;
@@ -622,6 +623,17 @@ netconf_route_get_src_addr_and_iface(netconf_handle         nh,
     }
     SIN(src_addr)->sin_family = route->family;
     memcpy(&(SIN(src_addr)->sin_addr.s_addr), route->src, sizeof(in_addr_t));
+
+    if (route->gateway != NULL)
+    {
+        SIN(gateway)->sin_family = route->family;
+        memcpy(&(SIN(gateway)->sin_addr.s_addr), route->gateway,
+               sizeof(in_addr_t));
+    }
+    else
+    {
+        SIN(gateway)->sin_family = AF_UNSPEC;
+    }
 
     if (if_indextoname(route->oifindex, ifname) == NULL)
     {


### PR DESCRIPTION
If the route to the target involves a gateway, use the gateway's MAC address as destination MAC.

Testing done: this patch fixed netconsole for agents running in containerized VMs