### PR TITLE
Various RGT fixes

### DIFF
--- a/tools/rgt/lib/tmpls/rgt_tmpls_lib.h
+++ b/tools/rgt/lib/tmpls/rgt_tmpls_lib.h
@@ -160,7 +160,8 @@ extern void rgt_tmpls_attrs_saved_free(rgt_attrs_t *attrs);
  *                 the list of arguments
  */
 extern void rgt_tmpls_attrs_add_fstr(rgt_attrs_t *attrs, const char *name,
-                                     const char *fmt_str, ...);
+                                     const char *fmt_str, ...)
+                                     TE_LIKE_PRINTF(3, 4);
 
 /**
  * Update the value of string attribute in the list of rgt attributes.
@@ -172,7 +173,8 @@ extern void rgt_tmpls_attrs_add_fstr(rgt_attrs_t *attrs, const char *name,
  *                 the list of arguments
  */
 extern void rgt_tmpls_attrs_set_fstr(rgt_attrs_t *attrs, const char *name,
-                                     const char *fmt_str, ...);
+                                     const char *fmt_str, ...)
+                                     TE_LIKE_PRINTF(3, 4);
 
 /**
  * Add a new uint32_t attribute into the list of rgt attributes.

--- a/tools/rgt/rgt-format/xml2html-multi/xml2html-multi.c
+++ b/tools/rgt/rgt-format/xml2html-multi/xml2html-multi.c
@@ -123,8 +123,8 @@ void rgt_process_cmdline(rgt_gen_ctx_t *ctx, poptContext con, int val)
 /* Add common global template parameters */
 void rgt_tmpls_attrs_add_globals(rgt_attrs_t *attrs)
 {
-    rgt_tmpls_attrs_add_fstr(attrs, "shared_url", multi_opts.shared_url);
-    rgt_tmpls_attrs_add_fstr(attrs, "docs_url", multi_opts.docs_url);
+    rgt_tmpls_attrs_add_fstr(attrs, "shared_url", "%s", multi_opts.shared_url);
+    rgt_tmpls_attrs_add_fstr(attrs, "docs_url", "%s", multi_opts.docs_url);
 }
 
 RGT_DEF_FUNC(proc_document_start)
@@ -430,7 +430,7 @@ lf_start(rgt_gen_ctx_t *ctx, rgt_depth_ctx_t *depth_ctx, const char *result,
 
             rgt_tmpls_attrs_set_uint32(attrs, "depth", i + 1);
             rgt_tmpls_attrs_set_uint32(attrs, "seq", cur_ctx->seq);
-            rgt_tmpls_attrs_set_fstr(attrs, "name", cur_user->name);
+            rgt_tmpls_attrs_set_fstr(attrs, "name", "%s", cur_user->name);
 
             rgt_tmpls_output(depth_user->dir_fd,
                              &xml2fmt_tmpls[LF_REF_PART], attrs);
@@ -456,11 +456,11 @@ lf_start(rgt_gen_ctx_t *ctx, rgt_depth_ctx_t *depth_ctx, const char *result,
 
         rgt_tmpls_attrs_set_uint32(attrs, "depth", ctx->depth);
         rgt_tmpls_attrs_set_uint32(attrs, "seq", depth_ctx->seq);
-        rgt_tmpls_attrs_set_fstr(attrs, "name", depth_user->name);
-        rgt_tmpls_attrs_set_fstr(attrs, "class", node_class);
+        rgt_tmpls_attrs_set_fstr(attrs, "name", "%s", depth_user->name);
+        rgt_tmpls_attrs_set_fstr(attrs, "class", "%s", node_class);
         if (is_test)
         {
-            rgt_tmpls_attrs_add_fstr(attrs, "result", result);
+            rgt_tmpls_attrs_add_fstr(attrs, "result", "%s", result);
             rgt_tmpls_output(prev_depth_user->dir_fd,
                              &xml2fmt_tmpls[LF_ROW_TEST], attrs);
         }
@@ -572,12 +572,12 @@ control_node_start(rgt_gen_ctx_t *ctx, rgt_depth_ctx_t *depth_ctx,
     rgt_tmpls_attrs_add_uint32(attrs, "seq", depth_ctx->seq);
     rgt_tmpls_output(depth_user->fd, &xml2fmt_tmpls[DOC_START], attrs);
 
-    rgt_tmpls_attrs_add_fstr(attrs, "node_type", node_type_str);
-    rgt_tmpls_attrs_add_fstr(attrs, "name", name);
-    rgt_tmpls_attrs_add_fstr(attrs, "result", result);
-    rgt_tmpls_attrs_add_fstr(attrs, "tin", tin);
-    rgt_tmpls_attrs_add_fstr(attrs, "test_id", node_id);
-    rgt_tmpls_attrs_add_fstr(attrs, "err", err);
+    rgt_tmpls_attrs_add_fstr(attrs, "node_type", "%s", node_type_str);
+    rgt_tmpls_attrs_add_fstr(attrs, "name", "%s", name);
+    rgt_tmpls_attrs_add_fstr(attrs, "result", "%s", result);
+    rgt_tmpls_attrs_add_fstr(attrs, "tin", "%s", tin);
+    rgt_tmpls_attrs_add_fstr(attrs, "test_id", "%s", node_id);
+    rgt_tmpls_attrs_add_fstr(attrs, "err", "%s", err);
     rgt_tmpls_output(depth_user->fd,
                      &xml2fmt_tmpls[DOC_CNTRL_NODE_TITLE], attrs);
 
@@ -587,8 +587,8 @@ control_node_start(rgt_gen_ctx_t *ctx, rgt_depth_ctx_t *depth_ctx,
                          &xml2fmt_tmpls[DOC_CNTRL_NODE_HASH], attrs);
     }
 
-    rgt_tmpls_attrs_add_fstr(attrs, "fname", fname);
-    rgt_tmpls_attrs_add_fstr(attrs, "class", node_class);
+    rgt_tmpls_attrs_add_fstr(attrs, "fname", "%s", fname);
+    rgt_tmpls_attrs_add_fstr(attrs, "class", "%s", node_class);
 
     fname[0] = '\0';
     if (depth_user->is_test)
@@ -596,7 +596,7 @@ control_node_start(rgt_gen_ctx_t *ctx, rgt_depth_ctx_t *depth_ctx,
         snprintf(fname, sizeof(fname), "n_%d_%d",
                  ctx->depth - 1, prev_depth_ctx->seq);
     }
-    rgt_tmpls_attrs_add_fstr(attrs, "par_name", fname);
+    rgt_tmpls_attrs_add_fstr(attrs, "par_name", "%s", fname);
 
     rgt_tmpls_output(prev_depth_user->fd,
                      &xml2fmt_tmpls[DOC_REF_TO_NODE], attrs);
@@ -720,7 +720,7 @@ RGT_DEF_FUNC(proc_log_msg_start)
         }
         else
         {
-            rgt_tmpls_attrs_add_fstr(attrs, "style_class_add", "");
+            rgt_tmpls_attrs_add_fstr(attrs, "style_class_add", "%s", "");
         }
 
         rgt_tmpls_attrs_add_uint32(attrs, "level_id",
@@ -1173,7 +1173,7 @@ RGT_DEF_FUNC(proc_log_msg_end)
             }
         }
 
-        rgt_tmpls_attrs_add_fstr(attrs, "level", depth_user->log_level);
+        rgt_tmpls_attrs_add_fstr(attrs, "level", "%s", depth_user->log_level);
         rgt_tmpls_output(depth_user->fd, &xml2fmt_tmpls[LOG_MSG_END],
                          attrs);
         rgt_tmpls_attrs_free(attrs);
@@ -1217,7 +1217,7 @@ RGT_DEF_FUNC(proc_logs_start)
         if (multi_opts.page_selector_set && multi_opts.cur_page >= 1)
         {
             rgt_tmpls_attrs_add_fstr(attrs, "selector_name", "top");
-            rgt_tmpls_attrs_add_fstr(attrs, "fname", depth_user->fname);
+            rgt_tmpls_attrs_add_fstr(attrs, "fname", "%s", depth_user->fname);
             rgt_tmpls_attrs_add_uint32(attrs, "cur_page",
                                        multi_opts.cur_page);
             rgt_tmpls_attrs_add_uint32(attrs, "pages_count",
@@ -1259,7 +1259,7 @@ RGT_DEF_FUNC(proc_logs_end)
         if (multi_opts.page_selector_set && multi_opts.cur_page >= 1)
         {
             rgt_tmpls_attrs_add_fstr(attrs, "selector_name", "bottom");
-            rgt_tmpls_attrs_add_fstr(attrs, "fname", depth_user->fname);
+            rgt_tmpls_attrs_add_fstr(attrs, "fname", "%s", depth_user->fname);
             rgt_tmpls_attrs_add_uint32(attrs, "cur_page",
                                        multi_opts.cur_page);
             rgt_tmpls_attrs_add_uint32(attrs, "pages_count",
@@ -1334,7 +1334,7 @@ RGT_DEF_FUNC(proc_meta_author_start)
     if (depth_user->fd != NULL)
     {
         attrs = rgt_tmpls_attrs_new(xml_attrs);
-        rgt_tmpls_attrs_add_fstr(attrs, "name", name);
+        rgt_tmpls_attrs_add_fstr(attrs, "name", "%s", name);
 
         rgt_tmpls_output(depth_user->fd,
                          &xml2fmt_tmpls[META_AUTHOR_START], attrs);

--- a/tools/rgt/rgt-format/xml2html-multi/xml2html-multi.c
+++ b/tools/rgt/rgt-format/xml2html-multi/xml2html-multi.c
@@ -123,8 +123,12 @@ void rgt_process_cmdline(rgt_gen_ctx_t *ctx, poptContext con, int val)
 /* Add common global template parameters */
 void rgt_tmpls_attrs_add_globals(rgt_attrs_t *attrs)
 {
-    rgt_tmpls_attrs_add_fstr(attrs, "shared_url", "%s", multi_opts.shared_url);
-    rgt_tmpls_attrs_add_fstr(attrs, "docs_url", "%s", multi_opts.docs_url);
+    rgt_tmpls_attrs_add_fstr(attrs, "shared_url", "%s",
+                             multi_opts.shared_url != NULL ?
+                                multi_opts.shared_url : "");
+    rgt_tmpls_attrs_add_fstr(attrs, "docs_url", "%s",
+                             multi_opts.docs_url != NULL ?
+                                multi_opts.docs_url : "");
 }
 
 RGT_DEF_FUNC(proc_document_start)

--- a/tools/rgt/rgt-format/xml2html-multi/xml2html-multi.c
+++ b/tools/rgt/rgt-format/xml2html-multi/xml2html-multi.c
@@ -642,9 +642,11 @@ control_node_end(rgt_gen_ctx_t *ctx, rgt_depth_ctx_t *depth_ctx,
         rgt_tmpls_output(fd, &xml2fmt_tmpls[DOC_END], NULL);
         fclose(fd);
         free(depth_user->fname);
+        depth_user->fname = NULL;
     }
 
     free(depth_user->name);
+    depth_user->name = NULL;
 
     lf_end(ctx, depth_ctx);
 }
@@ -1629,6 +1631,9 @@ static void
 free_depth_user_data_cb(void *data)
 {
     depth_ctx_user_t *depth_user = data;
+
+    free(depth_user->name);
+    free(depth_user->fname);
 
     te_dbuf_free(&depth_user->json_data);
 }

--- a/tools/rgt/rgt-format/xml2html/xml2html.c
+++ b/tools/rgt/rgt-format/xml2html/xml2html.c
@@ -73,7 +73,7 @@ RGT_DEF_FUNC(proc_document_start)
     }
 
     attrs = rgt_tmpls_attrs_new(xml_attrs);
-    rgt_tmpls_attrs_add_fstr(attrs, "DATADIR", prefix);
+    rgt_tmpls_attrs_add_fstr(attrs, "DATADIR", "%s", prefix);
     rgt_tmpls_output(gen_user->fd, &xml2fmt_tmpls[DOCUMENT_START], attrs);
     rgt_tmpls_attrs_free(attrs);
 }


### PR DESCRIPTION
A series of minor fixes in RGT focused mostly on memory safety.

Testing done: this patch fixed RGT segfaults on Ubuntu 22.04