### PR TITLE
TS-provided Configurator subtrees

### DIFF
--- a/agents/unix/main.c
+++ b/agents/unix/main.c
@@ -1542,6 +1542,15 @@ rcf_ch_rpc_server_thread(void *ready, int argc, char *argv[])
 }
 #endif
 
+#if TE_CONSTRUCTOR_AVAILABLE
+TE_CONSTRUCTOR_PRIORITY(101)
+#endif
+static void
+log_init(void)
+{
+    te_log_init("(unix)", te_log_message_file);
+}
+
 /**
  * Entry point of the Unix Test Agent.
  *
@@ -1587,7 +1596,9 @@ main(int argc, char **argv)
 #endif /* AT_SYSINFO */
 #endif
 
-    te_log_init("(unix)", te_log_message_file);
+#if !TE_CONSTRUCTOR_AVAILABLE
+    log_init();
+#endif
 
     te_kernel_log_set_system_func(&ta_system);
 

--- a/agents/unix/meson.build
+++ b/agents/unix/meson.build
@@ -5,6 +5,7 @@ conf_data = configuration_data()
 
 name = get_option('agent-unix-name')
 ta_platform = get_option('agent-unix-platform')
+ta_libs = get_option('agent-unix-libs')
 tadir = join_paths(get_option('agentsdir'), name)
 
 includes = []
@@ -42,7 +43,7 @@ ta_non_symtbl_libs = [
     'logger_core',
 ]
 
-foreach extra_lib : get_option('agent-unix-libs')
+foreach extra_lib : ta_libs
     if not ta_symtbl_libs.contains(extra_lib)
         ta_symtbl_libs += [ extra_lib ]
     endif
@@ -468,17 +469,19 @@ executable('ta', sources, generated_sources,
 #
 # Build ta_rcf_listener
 #
-rcf_listener_sources = files(
-    'ta_rcf_listener.c',
-)
+if 'comm_net_agent' in ta_libs
+    rcf_listener_sources = files(
+        'ta_rcf_listener.c',
+    )
 
-# Just use the ta dependencies: this seems to be enough
-executable('ta_rcf_listener', rcf_listener_sources,
-           install: true, install_dir: tadir,
-           include_directories: includes,
-           c_args: c_args,
-           link_args: link_args,
-           dependencies: deps)
+    # Just use the ta dependencies: this seems to be enough
+    executable('ta_rcf_listener', rcf_listener_sources,
+               install: true, install_dir: tadir,
+               include_directories: includes,
+               c_args: c_args,
+               link_args: link_args,
+               dependencies: deps)
+endif
 
 ta_scripts = files(
     'ta_clean_tce',

--- a/agents/unix/meson.build
+++ b/agents/unix/meson.build
@@ -474,13 +474,19 @@ if 'comm_net_agent' in ta_libs
         'ta_rcf_listener.c',
     )
 
-    # Just use the ta dependencies: this seems to be enough
+    rcf_listener_deps = [
+        dep_lib_static_logger_core,
+        dep_lib_static_logger_file,
+        dep_lib_static_tools,
+        dep_lib_static_comm_net_agent,
+    ]
+
     executable('ta_rcf_listener', rcf_listener_sources,
                install: true, install_dir: tadir,
                include_directories: includes,
                c_args: c_args,
                link_args: link_args,
-               dependencies: deps)
+               dependencies: rcf_listener_deps)
 endif
 
 ta_scripts = files(

--- a/include/te_compiler.h
+++ b/include/te_compiler.h
@@ -23,6 +23,7 @@
 #define __has_attribute_oldgcc_format 1
 #define __has_attribute_oldgcc_deprecated 1
 #define __has_attribute_oldgcc_sentinel 1
+#define __has_attribute_oldgcc_constructor 1
 #endif /* __GNUC__ */
 #endif
 
@@ -95,6 +96,20 @@
 #define TE_DEPRECATED __attribute__((deprecated))
 #else
 #define TE_DEPRECATED
+#endif
+
+#if __has_attribute(constructor)
+/**
+ * Mark a function as a constructor. It will be executed
+ * before the main function.
+ */
+#define TE_CONSTRUCTOR_AVAILABLE 1
+#define TE_CONSTRUCTOR_PRIORITY(n) __attribute__((constructor(n)))
+#define TE_CONSTRUCTOR __attribute__((constructor))
+#else
+#define TE_CONSTRUCTOR_AVAILABLE 0
+#define TE_CONSTRUCTOR_PRIORITY(n) CONSTRUCTOR ATTRIBUTE UNSUPPORTED BY COMPILER
+#define TE_CONSTRUCTOR CONSTRUCTOR ATTRIBUTE UNSUPPORTED BY COMPILER
 #endif
 
 /*

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -198,6 +198,8 @@ foreach l : all_libs
         deps = []
         # List of dependencies in TE library name format
         te_libs = []
+        # Whether this library needs to be linked wholly
+        link_whole = false
         # logger_core is required dependency for everything else
         if l != 'logger_core'
             te_libs += [ 'logger_core' ]
@@ -275,9 +277,15 @@ foreach l : all_libs
                 set_variable('te_lib_' + libname, lib)
                 lib_static = lib
 
-                dep = declare_dependency(link_with: lib,
-                                         include_directories: includes,
-                                         dependencies: deps_static)
+                if link_whole
+                    dep = declare_dependency(link_whole: lib,
+                                             include_directories: includes,
+                                             dependencies: deps_static)
+                else
+                    dep = declare_dependency(link_with: lib,
+                                             include_directories: includes,
+                                             dependencies: deps_static)
+                endif
                 set_variable('dep_lib_static_' + libname, dep)
             endif
             if build_lib_shared

--- a/suites/selftest/conf/builder.conf
+++ b/suites/selftest/conf/builder.conf
@@ -50,8 +50,10 @@ define([TE_AGENT_BUILD], [
                         [logger_core tools conf_oid asn ndn comm_net_agent \
                          loggerta agentlib rcfpch tad netconf rpcxdr \
                          rpctransport rpc_types rpcserver ta_job \
-                         rpcs_job rpcs_serial],
+                         rpcs_job rpcs_serial cs_lib],
                         [${$1_BUILD}])
+
+            TE_LIB_PARMS([cs_lib], [${$1_TA_TYPE}], [${TS_TOPDIR}/ts/cs/lib])
 
             # We do not build agent part of DPDK and BPF RPC, because
             # they need special dependencies on the agent
@@ -74,7 +76,7 @@ define([TE_AGENT_BUILD], [
                            isc-dhcp-server l2tp named nginx openvpn \
                            radvd rsh smtp socks telnet tftp vncserver vtund'
                          --enable-pci],
-                       [], [], [], [comm_net_agent])
+                       [], [], [], [comm_net_agent cs_lib])
 
             TE_TA_APP([ta_rpcprovider], [${$1_TA_TYPE}], [${$1_TA_TYPE}],
                       [ta_rpcprovider], [], [],

--- a/suites/selftest/conf/cs.conf
+++ b/suites/selftest/conf/cs.conf
@@ -219,3 +219,9 @@
 - set:
     - oid: "/volatile:/alien_link_addr:"
       value: "${TE_ALIEN_LINK_ADDR:-00:10:29:38:47:56}"
+
+- register:
+    - oid: "/agent/ts_lib_helloworld"
+      access: read_only
+      type: string
+

--- a/suites/selftest/conf/trc/cs.trc.xml
+++ b/suites/selftest/conf/trc/cs.trc.xml
@@ -277,5 +277,14 @@
                 <notes/>
             </iter>
         </test>
+
+        <test name="ts_subtree" type="script">
+            <objective>Check that TS-provided subtrees work correctly</objective>
+            <notes/>
+            <iter result="PASSED">
+                <arg name="env"/>
+                <notes/>
+            </iter>
+        </test>
     </iter>
 </test>

--- a/suites/selftest/ts/cs/lib/main.c
+++ b/suites/selftest/ts/cs/lib/main.c
@@ -1,0 +1,50 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright (c) 2024 OKTET Ltd. All rights reserved. */
+/** @file
+ * @brief TS-provided subtree
+ */
+
+#define TE_LGR_USER     "CS Lib Hello World"
+
+#include "te_compiler.h"
+
+#if TE_CONSTRUCTOR_AVAILABLE
+
+#include "te_config.h"
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "te_stdint.h"
+#include "te_errno.h"
+#include "logger_api.h"
+#include "rcf_ch_api.h"
+#include "rcf_pch.h"
+#include "logger_api.h"
+#include "logger_file.h"
+
+static te_errno
+helloworld_get(unsigned int gid, const char *oid, char *value)
+{
+    UNUSED(gid);
+    UNUSED(oid);
+
+    strcpy(value, "Hello, world!");
+
+    return 0;
+}
+
+RCF_PCH_CFG_NODE_RO(helloworld, "ts_lib_helloworld", NULL, NULL, helloworld_get);
+
+TE_CONSTRUCTOR
+static void
+pch_init(void)
+{
+    te_errno rc;
+
+    rc = rcf_pch_add_node("/agent", &helloworld);
+    if (rc != 0)
+        ERROR("Failed to init the PCH node: %r", rc);
+}
+
+#endif /* TE_CONSTRUCTOR_AVAILABLE */

--- a/suites/selftest/ts/cs/lib/meson.build
+++ b/suites/selftest/ts/cs/lib/meson.build
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024 OKTET Ltd. All rights reserved.
+
+sources += files('main.c')
+
+te_libs += [
+    'rcfpch',
+    'tools',
+]
+
+link_whole = true

--- a/suites/selftest/ts/cs/meson.build
+++ b/suites/selftest/ts/cs/meson.build
@@ -16,6 +16,7 @@ tests = [
     'process_autorestart',
     'process_ping',
     'set_restore',
+    'ts_subtree',
     'uname',
     'unused_backup',
     'user',

--- a/suites/selftest/ts/cs/package.xml
+++ b/suites/selftest/ts/cs/package.xml
@@ -269,5 +269,12 @@
             </arg>
         </run>
 
+        <run>
+            <script name="ts_subtree"/>
+            <arg name="env">
+                <value>{{{'pco_iut':IUT}}}</value>
+            </arg>
+        </run>
+
     </session>
 </package>

--- a/suites/selftest/ts/cs/ts_subtree.c
+++ b/suites/selftest/ts/cs/ts_subtree.c
@@ -1,0 +1,76 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright (c) 2024 OKTET Ltd. All rights reserved. */
+/** @file
+ * @brief TS-provided subtree
+ */
+
+/** @page ts_subtree TS-provided subtree
+ *
+ * @objective Check that TS-provided subtrees work correctly
+ *
+ * This test suite includes a library that, when linked to a TA,
+ * should export an additional subtree for that agent.
+ *
+ * This functionality has only been implemented for Unix TAs, so
+ * the test is going to skip other types of agents.
+ *
+ * @par Test sequence:
+ *
+ */
+
+#ifndef DOXYGEN_TEST_SPEC
+
+#define TE_TEST_NAME    "cs/ts_subtree"
+
+#ifndef TEST_START_VARS
+#define TEST_START_VARS TEST_START_ENV_VARS
+#endif
+
+#ifndef TEST_START_SPECIFIC
+#define TEST_START_SPECIFIC TEST_START_ENV
+#endif
+
+#ifndef TEST_END_SPECIFIC
+#define TEST_END_SPECIFIC TEST_END_ENV
+#endif
+
+#include "te_config.h"
+#include "tapi_cfg.h"
+#include "tapi_test.h"
+#include "tapi_env.h"
+
+static te_errno
+check_subtree(const char *ta, void *cookie)
+{
+    te_errno  rc;
+    char     *value = NULL;
+
+    UNUSED(cookie);
+
+    rc = cfg_get_string(&value, "/agent:%s/ts_lib_helloworld:", ta);
+    if (rc != 0)
+    {
+        ERROR("Failed to get the ts_lib_helloworld instance from %s: %r", ta, rc);
+        return rc;
+    }
+
+    RING("Successfully got '%s' from TA %s", value, ta);
+
+    free(value);
+    return 0;
+}
+
+int
+main(int argc, char **argv)
+{
+    TEST_START;
+
+    CHECK_RC(rcf_foreach_ta(check_subtree, NULL));
+
+    TEST_SUCCESS;
+
+cleanup:
+    TEST_END;
+}
+
+#endif /* !DOXYGEN_TEST_SPEC */


### PR DESCRIPTION
The minimal set of changes required to allow test suites to register their own Configurator subtrees.

PCH nodes can be registered by ELF constructors added to the Unix Test Agent by linking an external library provided by a test suite.

Testing done: these changes have been successfully used to implement additional TA functionality in one of our test suites