### PR TITLE
External buffer awareness and sysfs-friendliness for file read utility function

### DIFF
--- a/lib/tools/te_file.c
+++ b/lib/tools/te_file.c
@@ -408,6 +408,10 @@ te_file_read_string(te_string *dest, bool binary,
         goto out;
     }
 
+    /* Some filesystems, e.g. sysfs, do not report file size correctly. */
+    if (st.st_blocks == 0 && st.st_size > 0)
+        st.st_size = 0;
+
     if (maxsize != 0 && st.st_size > maxsize)
     {
         ERROR("File %s's size (%zu) is larger than %zu",


### PR DESCRIPTION
Ignore useless file sizes reported by `stat` and do not panic if user passes a `te_string` bound to an external buffer. This makes it possible to read sysfs files directly into buffers used for RCF values.

Testing done: these changes were successfully used to expose information from sysfs through Configurator