### PR TITLE
Increase log buffer size

### DIFF
--- a/lib/rcfpch/rcf_pch_internal.h
+++ b/lib/rcfpch/rcf_pch_internal.h
@@ -22,8 +22,15 @@
 #include "rcf_ch_api.h"
 #include "logger_api.h"
 
-/** Size of the log data sent in one request */
-#define RCF_PCH_LOG_BULK        8192
+/**
+ * Size of the log data sent in one request.
+ * This value should not be less than LOGFORK_MAXLEN, because LOGFORK_MAXLEN
+ * is a maximum length of message which is passed to log messages ring buffer
+ * and RCF_PCH_LOG_BULK is a size of buffer to get message from ring buffer.
+ * And if size of this buffer is less then message in ring buffer, than TE
+ * never can get this message from ring buffer.
+ */
+#define RCF_PCH_LOG_BULK        16384
 
 /**
  * Skip spaces in the command.


### PR DESCRIPTION
Increase RCF_PCH_LOG_BULK value, because it should be not less then LOGFORK_MAXLEN or it leads to problems with reading messages from log messages ring buffer.