### PR TITLE
lib/tad: always compute L4 datagram size from IP packet size

### DIFF
--- a/lib/tad/ipstack/tad_ip4_layer.c
+++ b/lib/tad/ipstack/tad_ip4_layer.c
@@ -970,6 +970,7 @@ tad_ip4_match_do_cb(csap_p           csap,
     unsigned int            bitoff = 0;
     tad_data_unit_t        *ip4_hdr_h_cksum_du;
     tad_cksum_str_code      cksum_str_code;
+    size_t                  hdr_sz;
 
     UNUSED(ptrn_pdu);
 
@@ -1031,18 +1032,19 @@ tad_ip4_match_do_cb(csap_p           csap,
         }
     }
 
+    hdr_sz = WORD_4BYTE * pkt_data->hdr.dus[1].val_i32;
+
     if (cksum_str_code != TAD_CKSUM_STR_CODE_NONE)
     {
         uint8_t    *ip4_header_bin;
         uint16_t    h_cksum;
 
-        ip4_header_bin = TE_ALLOC(WORD_4BYTE * pkt_data->hdr.dus[1].val_i32);
+        ip4_header_bin = TE_ALLOC(hdr_sz);
 
         tad_pkt_read_bits(pdu, 0, WORD_32BIT * pkt_data->hdr.dus[1].val_i32,
                           ip4_header_bin);
 
-        h_cksum = calculate_checksum((void *)ip4_header_bin,
-                                     WORD_4BYTE * pkt_data->hdr.dus[1].val_i32);
+        h_cksum = calculate_checksum((void *)ip4_header_bin, hdr_sz);
         h_cksum = ~h_cksum;
 
         free(ip4_header_bin);
@@ -1063,6 +1065,7 @@ tad_ip4_match_do_cb(csap_p           csap,
         return rc;
     }
 
+    meta_pkt->ip_pld_sz = pkt_data->hdr.dus[3].val_i32 /* total */ - hdr_sz;
     EXIT(CSAP_LOG_FMT "OK", CSAP_LOG_ARGS(csap));
 
     return 0;

--- a/lib/tad/ipstack/tad_ip6_layer.c
+++ b/lib/tad/ipstack/tad_ip6_layer.c
@@ -1878,6 +1878,7 @@ tad_ip6_match_do_cb(csap_p           csap,
         return rc;
     }
 
+    meta_pkt->ip_pld_sz = pkt_data->hdr.dus[3].val_i32;
     EXIT(CSAP_LOG_FMT "OK", CSAP_LOG_ARGS(csap));
 
     return rc;

--- a/lib/tad/ipstack/tad_ipstack_cksum_tools.c
+++ b/lib/tad/ipstack/tad_ipstack_cksum_tools.c
@@ -118,7 +118,7 @@ tad_l4_match_cksum_advanced(csap_p              csap,
     /* Re-create the datagram */
 
     /* Copy L4 header + L4 payload */
-    l4_datagram_len = pdu->segs_len;
+    l4_datagram_len = meta_pkt->ip_pld_sz;
     l4_datagram_bin = TE_ALLOC(l4_datagram_len);
 
     tad_pkt_read_bits(pdu, 0, BITS_PER_BYTE * l4_datagram_len, l4_datagram_bin);
@@ -131,51 +131,9 @@ tad_l4_match_cksum_advanced(csap_p              csap,
     tad_pkt_read_bits(ip_pdu, 0, IP_HDR_VERSION_LEN, &ip_version);
 
     if (ip_version == IP4_VERSION)
-    {
-        uint16_t ip4_tot_len;
-
-        /*
-         * To avoid calculating wrong TCP checksum in a frame of a minimum
-         * length (eg. 64 bytes) which includes trailing zero bytes at the
-         * end, but does not count for them in IPv4 total length field, we
-         * count the extra bytes ab initio and fix 'l4_datagram_len' value
-         *
-         * (We suppose that 'ip_pdu->segs_len' is the whole IP packet length)
-         */
-        tad_pkt_read_bits(ip_pdu, IP4_HDR_TOTAL_LEN_OFFSET * BITS_PER_BYTE,
-                          sizeof(ip4_tot_len) * BITS_PER_BYTE,
-                          (uint8_t *)&ip4_tot_len);
-
-        ip4_tot_len = ntohs(ip4_tot_len);
-
-        if (ip_pdu->segs_len > ip4_tot_len)
-        {
-            size_t trailer_len = ip_pdu->segs_len - ip4_tot_len;
-            if (l4_datagram_len > trailer_len)
-            {
-                l4_datagram_len -= trailer_len;
-            }
-            else
-            {
-                free(l4_datagram_bin);
-                return TE_RC(TE_TAD_CSAP, TE_ETADNOTMATCH);
-            }
-        }
-
         tad_ip4_prepare_addresses(ip_pdu, &ip_dst_addr, &ip_src_addr);
-    }
     else
-    {
-        /*
-         * In a typical case of an Ethernet frame we have (at least)
-         * 14 bytes (Ethernet header length) + 40 bytes (IPv6 header
-         * length) = 54 bytes of L2-L3 header space, and addition of
-         * L4 header size covers the minimum frame length, hence, we
-         * don't consider zero trailer prior to checksum calculation
-         */
-
         tad_ip6_prepare_addresses(ip_pdu, &ip_dst_addr, &ip_src_addr);
-    }
 
     /* Calculate the checksum */
     rc = TE_RC(TE_TAD_CSAP, te_ipstack_calc_l4_cksum(SA(&ip_dst_addr),

--- a/lib/tad/tad_recv_pkt.h
+++ b/lib/tad/tad_recv_pkt.h
@@ -53,6 +53,8 @@ typedef struct tad_recv_pkt {
 
     int                 match_unit;    /**< Index of matched pattern unit,
                                             -1 if packet mismatched */
+    size_t              ip_pld_sz;  /**< IPv4/IPv6 packet payload size,
+                                         as per the IP header */
 } tad_recv_pkt;
 
 


### PR DESCRIPTION
IPv6 iterations of 'xmit/one_packet' have been failing lately on a configuration that cannot be instructed to drop FCS from the incoming packets, hence the patch. Thank you.