### PR TITLE
Fix problems with allocating hugepages via Configurator after changes in substrings API

### DIFF
--- a/agents/unix/conf/base/conf_mem.c
+++ b/agents/unix/conf/base/conf_mem.c
@@ -780,10 +780,7 @@ hugepages_mountpoint_list(unsigned int gid, const char *oid, const char *sub_id,
 
     if (rc == 0)
     {
-        rc = te_string_replace_all_substrings(&result, PATH_DELIMITER, "/");
-        if (rc != 0)
-            return rc;
-
+        te_string_replace_all_substrings(&result, PATH_DELIMITER, "/");
         *list = result.ptr;
     }
     else

--- a/lib/tools/te_string.c
+++ b/lib/tools/te_string.c
@@ -799,6 +799,9 @@ te_substring_find(te_substring_t *substr, const char *str)
     if (!te_substring_is_valid(substr))
         return false;
 
+    if (substr->base->ptr == NULL)
+        return false;
+
     ch = strstr(substr->base->ptr + substr->start, str);
     if (ch == NULL)
     {


### PR DESCRIPTION
The recent changes in TE led to a segfault while allocating hugepages via Configurator:
```
Thread 1 (Thread 0x7f955cdcac80 (LWP 37019)):
#0  __strchr_evex () at ../sysdeps/x86_64/multiarch/strchr-evex.S:78
#1  0x00007f955d399000 in __strstr_sse2 (haystack=<optimized out>, needle=0x563bbce0ce9a "/") at ../string/strstr.c:84
#2  0x0000563bbcd4af99 in te_substring_find (substr=0x7fffd5398890, str=0x563bbce0ce9a "/") at ../src/lib/tools/te_string.c:802
#3  0x0000563bbcd4bc3c in replace_next_substring (substr=0x7fffd5398890, new=0x563bbce0ce98 "$", old=0x563bbce0ce9a "/") at ../src/lib/tools/te_string.c:1098
#4  0x0000563bbcd4bd4c in te_string_replace_all_substrings (str=0x7fffd5398910, new=0x563bbce0ce98 "$", old=0x563bbce0ce9a "/") at ../src/lib/tools/te_string.c:1122
#5  0x0000563bbccdbdc8 in hugepages_mountpoint_list (gid=228, oid=0x7fffd5399b60 "/agent:Forwarder/mem:/hugepages:1048576", sub_id=0x563bbce8e6a0 <node_hugepage_mountpoint> "mountpoint", list=0x7fffd5398aa0, unused=0x563bbe1a3315 "", hugepage_size=0x563bbe1a3320 "1048576") at ../src/agents/unix/conf/base/conf_mem.c:783
#6  0x0000563bbcd723d2 in create_wildcard_inst_list (obj=0x563bbce8e6a0 <node_hugepage_mountpoint>, parsed=0x7fffd5399b60 "/agent:Forwarder/mem:/hugepages:1048576", oid=0x7fffd539cbc2 "/mountpoint:*/...", full_oid=0x563bbdff6444 "/agent:Forwarder/mem:*/hugepages:*/mountpoint:*/...", list=0x7fffd539cb88) at ../src/lib/rcfpch/rcf_pch_conf.c:326
#7  0x0000563bbcd72693 in create_wildcard_inst_list (obj=0x563bbce8e780 <node_hugepages>, parsed=0x7fffd539aba0 "/agent:Forwarder/mem:", oid=0x7fffd539cbb6 "/hugepages:*/mountpoint:*/...", full_oid=0x563bbdff6444 "/agent:Forwarder/mem:*/hugepages:*/mountpoint:*/...", list=0x7fffd539cb88) at ../src/lib/rcfpch/rcf_pch_conf.c:381
#8  0x0000563bbcd72693 in create_wildcard_inst_list (obj=0x563bbce8e860 <node_mem>, parsed=0x7fffd539bbe0 "/agent:Forwarder", oid=0x7fffd539cbb0 "/mem:*/hugepages:*/mountpoint:*/...", full_oid=0x563bbdff6444 "/agent:Forwarder/mem:*/hugepages:*/mountpoint:*/...", list=0x7fffd539cb88) at ../src/lib/rcfpch/rcf_pch_conf.c:381
#9  0x0000563bbcd72693 in create_wildcard_inst_list (obj=0x563bbcea3a40 <node_agent>, parsed=0x0, oid=0x7fffd539cba0 "/agent:Forwarder/mem:*/hugepages:*/mountpoint:*/...", full_oid=0x563bbdff6444 "/agent:Forwarder/mem:*/hugepages:*/mountpoint:*/...", list=0x7fffd539cb88) at ../src/lib/rcfpch/rcf_pch_conf.c:381
#10 0x0000563bbcd72cf9 in process_wildcard (conn=0x563bbdfc02e0, cbuf=0x563bbdff6430 "SID 0 configure get /agent:Forwarder/mem:*/hugepages:*/mountpoint:*/...", buflen=4096, answer_plen=6, oid=0x563bbdff6444 "/agent:Forwarder/mem:*/hugepages:*/mountpoint:*/...") at ../src/lib/rcfpch/rcf_pch_conf.c:576
#11 0x0000563bbcd73ee3 in rcf_pch_configure (conn=0x563bbdfc02e0, cbuf=0x563bbdff6430 "SID 0 configure get /agent:Forwarder/mem:*/hugepages:*/mountpoint:*/...", buflen=4096, answer_plen=6, ba=0x0, cmdlen=72, op=RCF_CH_CFG_GET, oid=0x563bbdff6444 "/agent:Forwarder/mem:*/hugepages:*/mountpoint:*/...", val=0x0) at ../src/lib/rcfpch/rcf_pch_conf.c:999
#12 0x0000563bbcd6dfff in rcf_pch_run (confstr=0x7fffd53a0c12 "17505", info=0x7fffd539ed40 "PID 37019") at ../src/lib/rcfpch/rcf_pch.c:697
#13 0x0000563bbccb3059 in main (argc=4, argv=0x7fffd539ee78) at ../src/agents/unix/main.c:1772
```

The suggested patches fix this problem.