### PR TITLE
trc: add ability to set unknown test/iteration handling

### DIFF
--- a/doc/xsd/trc_db.xsd
+++ b/doc/xsd/trc_db.xsd
@@ -40,6 +40,20 @@
         </xsd:restriction>
     </xsd:simpleType>
 
+    <xsd:simpleType name="unknownExpStatus">
+        <xsd:annotation>
+            <xsd:documentation>
+                Enumeration of ways to handle unknown test/iteration.
+                Are they treated as ok (only PASSED iterations without any
+                verdict), or unknown.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:token">
+            <xsd:enumeration value="passed_ok"/>
+            <xsd:enumeration value="passed_unknown"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
     <xsd:complexType name="iter">
         <xsd:annotation>
             <xsd:documentation>
@@ -372,6 +386,13 @@
                         If true, this TRC database was created by merging other
                         TRC databases. So it may contain more than one iteration
                         entry matching a given test iteration.
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="unknown_exp_status" type="te-trc:unknownExpStatus" default="passed_unknown">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        How to treat unknown test/iteration.
                     </xsd:documentation>
                 </xsd:annotation>
             </xsd:attribute>

--- a/include/te_test_result.h
+++ b/include/te_test_result.h
@@ -114,6 +114,34 @@ typedef enum trc_verdict {
                                  expected results */
 } trc_verdict;
 
+/** How to treat unknown test/iteration */
+typedef enum trc_unknown_exp_status {
+    /** Unknown passing test is unknown */
+    TRC_UNKNOWN_EXP_STATUS_PASSED_UNKNOWN,
+    /** Unknown passing test is ok */
+    TRC_UNKNOWN_EXP_STATUS_PASSED_OK,
+} trc_unknown_exp_status;
+
+/**
+ * Convert trc_unknown_exp_status to string representation.
+ *
+ * @param status        Status to be converted to string
+ *
+ * @return Pointer to string representation.
+ */
+static inline const char *
+trc_unknown_exp_status_to_str(trc_unknown_exp_status status)
+{
+    switch (status)
+    {
+        case TRC_UNKNOWN_EXP_STATUS_PASSED_UNKNOWN:
+            return "passed_unknown";
+        case TRC_UNKNOWN_EXP_STATUS_PASSED_OK:
+            return "passed_ok";
+        default:
+             return "<UNKNOWN>";
+    }
+}
 
 /** Initialize test result by defaults. */
 static inline void

--- a/lib/trc/db_io.c
+++ b/lib/trc/db_io.c
@@ -1579,6 +1579,8 @@ trc_db_open_ext(const char *location, te_trc_db **db, int flags)
     }
     else
     {
+        const char *unknown_exp_status;
+
         rc = get_boolean_prop(node, "last_match", &(*db)->last_match);
         if (rc != 0)
             return rc;
@@ -1593,6 +1595,24 @@ trc_db_open_ext(const char *location, te_trc_db **db, int flags)
         {
             INFO("Version of the TRC DB is missing");
         }
+
+        unknown_exp_status = XML2CHAR(xmlGetProp(node,
+                                    CONST_CHAR2XML("unknown_exp_status")));
+        if (unknown_exp_status != NULL)
+        {
+            if (strcmp(unknown_exp_status, "passed_ok") == 0)
+                (*db)->unknown_exp_status =
+                    TRC_UNKNOWN_EXP_STATUS_PASSED_OK;
+            else if (strcmp(unknown_exp_status, "passed_unknown") == 0)
+                (*db)->unknown_exp_status =
+                    TRC_UNKNOWN_EXP_STATUS_PASSED_UNKNOWN;
+        }
+        else
+        {
+            (*db)->unknown_exp_status =
+                TRC_UNKNOWN_EXP_STATUS_PASSED_UNKNOWN;
+        }
+
 
         node = xmlNodeChildren(node);
         (*db)->tests.node = node;

--- a/lib/trc/db_walker.c
+++ b/lib/trc/db_walker.c
@@ -909,6 +909,8 @@ const trc_exp_result *
 trc_db_walker_get_exp_result(const te_trc_db_walker *walker,
                              const tqh_strings      *tags)
 {
+    const trc_exp_result *exp_result;
+
     assert(walker->is_iter);
 
     if (walker->unknown > 0)
@@ -919,8 +921,24 @@ trc_db_walker_get_exp_result(const te_trc_db_walker *walker,
          */
         VERB("Iteration is not known");
         /* Test iteration is unknown. No expected result. */
-        return NULL;
+        switch (walker->db->unknown_exp_status)
+        {
+            case TRC_UNKNOWN_EXP_STATUS_PASSED_OK:
+                exp_result = exp_defaults_get(TE_TEST_PASSED);
+                break;
+            case TRC_UNKNOWN_EXP_STATUS_PASSED_UNKNOWN:
+                exp_result = exp_defaults_get(TE_TEST_UNSPEC);
+                break;
+            default:
+                assert(0);
+                break;
+        }
+    }
+    else
+    {
+        exp_result = trc_db_iter_get_exp_result(walker->iter, tags,
+                                                walker->db->last_match);
     }
 
-    return trc_db_iter_get_exp_result(walker->iter, tags, walker->db->last_match);
+    return exp_result;
 }

--- a/lib/trc/trc_db.h
+++ b/lib/trc/trc_db.h
@@ -167,6 +167,8 @@ struct te_trc_db {
     trc_globals     globals;
     bool last_match; /**< Choose the last match expectation */
     bool merged; /**< True if other databases were merged into this one */
+    /** How to treat unknown test/iteration */
+    trc_unknown_exp_status unknown_exp_status;
 };
 
 /** Kinds of matching of iteration TRC with iteration from XML log */


### PR DESCRIPTION
It's a long living issue that in a number of
suites default behaviour is PASSED will always be
treated as ok.

This patch adds an ability to parameterize this
behaviour on a per-TRC database basis. Keeping the default behaviour as PASSED_UNKNOWN, i.e. treat
PASSED that are not in the DB as unknown.

Signed-off-by: Konstantin Ushakov <kushakov@oktet.co.il>
Acked-by: Yurij Plotnikov <yurij.plotnikov@arknetworks.am>