### PR TITLE
lib/rcfpch: change handling of missing RPC server

### DIFF
--- a/lib/rcfpch/rcf_pch_rpc.c
+++ b/lib/rcfpch/rcf_pch_rpc.c
@@ -1844,9 +1844,9 @@ rcf_pch_rpc(struct rcf_comm_connection *conn, int sid,
     rpcs = rcf_pch_find_rpcserver(server);
     if (rpcs == NULL)
     {
-        ERROR("Failed to find RPC server %s", server);
+        RING("RPC server '%s' not found", server);
         pthread_mutex_unlock(&lock);
-        RETERR(TE_ENOENT);
+        RETERR(TE_ESRCH);
     }
 
     if (rpcs->dead)


### PR DESCRIPTION
We have cases where RPC server is temporary not available, because RPC provider is being restarted. While a monitor test or other user is running and trying to access it.

In this case we don't want to log an error and polute the log, moreover we want to return something sensible and distinguish this case from other errors.

TE_ENOENT is returned in various cases while TE_ESRCH looks closer to reality.

Signed-off-by: Oleg Sadakov <oleg.sadakov@arknetworks.am>
Acked-by: Yurij Plotnikov <yurij.plotnikov@arknetworks.am>