### PR TITLE
agent/unix: clear PCI driver override when unbinding

### DIFF
--- a/agents/unix/conf/base/conf_pci.c
+++ b/agents/unix/conf/base/conf_pci.c
@@ -2091,6 +2091,10 @@ try_override(const pci_device *dev, const char *drv)
     if (fd < 0)
         return rc;
 
+    /* Driver override is cleared only when a newline symbol is written. */
+    if (*drv == '\0')
+        drv = "\n";
+
     ret = write(fd, drv, strlen(drv));
     rc = (ret < 0) ? TE_OS_RC(TE_TA_UNIX, errno) : 0;
 
@@ -2182,6 +2186,13 @@ pci_driver_set(unsigned int gid, const char *oid, const char *value,
 
         rc = maybe_create_device(dev, value);
         if (rc != 0)
+            return rc;
+    }
+    else
+    {
+        /* Clear the driver override we might have set previously. */
+        rc = try_override(dev, value);
+        if (rc != 0 && TE_RC_GET_ERROR(rc) != TE_EOPNOTSUPP)
             return rc;
     }
 


### PR DESCRIPTION
Leaving the driver override after unbinding the device driver can prevent automatic binding when a module with a compatible driver is loaded later. This can lead to surprises to the end user of the test suite. Fix the problem by always explicitly clearing the override.

Fixes: 52ca52e42f8b ("agent/unix: support binding to vfio-pci with driver_override")

Reviewed-by: Ivan Malov <ivan.malov@arknetworks.am>

Testing done: tested with dpdk-pmd-ts. The driver override is now cleared after TE run has finished