### PR TITLE
scripts: resolve symlink of run script

### DIFF
--- a/scripts/lib.meta
+++ b/scripts/lib.meta
@@ -209,7 +209,7 @@ te_meta_set_ts() {
 te_meta_test_suite() {
     local ts_name="$1"
     local ts_prefix="$2"
-    local ts_dir="$(cd "$(dirname "$(which "$0")")"/.. ; pwd -P)"
+    local ts_dir="$(cd "$(dirname $(realpath "$(which "$0")"))"/.. ; pwd -P)"
 
     if [[ -z "${ts_prefix}" ]] ; then
         ts_prefix="${ts_name^^}"


### PR DESCRIPTION
The main run script of test suite can be symlink (e.g. Sapi-ts), so resolve it to the real file path.

Signed-off-by: Yurij Plotnikov <yurij.plotnikov@arknetworks.am>
Reviewed-by: Viacheslav Galaktionov <viacheslav.galaktionov@arknetworks.am>

Testing done:
This was tested with the following patch in sapi-ts: https://github.com/Xilinx-CNS/cns-sapi-ts/commit/14841d6f16e5c37f7486a8cb118e09f3508560d7

Without this patch sapi-ts fails with --meta option. It prints on console:
>> ./run.sh --cfg=<some_cfg> --log-html=html --ool=onload --tester-run=sockapi-ts/usecases/read_write%1 -q --meta
TE_BASE=<some path>
SF_TS_CONFDIR=<some path>
Guessing TE_TS_RIGSDIR
TE_TS_RIGSDIR=<some path>
Guessing SFC_ONLOAD_LIB
SFC_ONLOAD_LIB=<some path>
And then stops.

With this patch it runs test successfuly and generates metadata.