### PR TITLE
User/okt kosovnn/st 2750

### DIFF
--- a/lib/rpcserver/rpc_server.h
+++ b/lib/rpcserver/rpc_server.h
@@ -1155,6 +1155,38 @@ extern sigset_t rpcs_received_signals;
 extern tarpc_siginfo_t last_siginfo;
 
 /**
+ * Macros to define one of two syscall function wrappers content. The macros
+ * should be used together and are disigned to have abbility to add arguments
+ * in syscall calling.
+ *
+ * @param _lib_postfix Postfix in wrapper name (empty or "_dl")
+ * @param _lib_flag    Flags to resolve function name (from tarpc_lib_flags)
+ * @param _lib_name    Name of the library in error message
+ * @param _name        Function name (bind, connect, etc.)
+ * @param _rettype     Return type (according to man _name)
+ * @param _args        Arguments list (according to man _name)
+ * @param ...          Values of arguments
+ */
+#define TARPC_DECLARE_SYSCALL_WRAPPER_FUNC_BEGIN(_lib_postfix, _lib_flag,   \
+                                                 _lib_name, _name,          \
+                                                 _rettype, _args, ...)      \
+_rettype _name##_te_wrap_syscall##_lib_postfix _args                        \
+{                                                                           \
+    static api_func syscall_func = NULL;                                    \
+                                                                            \
+    if (syscall_func == NULL &&                                             \
+        tarpc_find_func(_lib_flag, "syscall", &syscall_func) != 0)          \
+    {                                                                       \
+        syscall_func = NULL;                                                \
+        ERROR("Failed to find function \"syscall\" in "_lib_name);          \
+        return -1;                                                          \
+    }                                                                       \
+    return (_rettype)syscall_func(SYS_##_name, ##__VA_ARGS__
+
+#define TARPC_DECLARE_SYSCALL_WRAPPER_FUNC_END                              \
+                                                            );              \
+}
+/**
  * Macro to define syscall function wrapper content.
  *
  * @param _name     Function name (bind, connect, etc.)
@@ -1163,33 +1195,15 @@ extern tarpc_siginfo_t last_siginfo;
  * @param ...       Values of arguments
  */
 #define TARPC_SYSCALL_WRAPPER(_name, _rettype, _args, ...)                  \
-_rettype _name##_te_wrap_syscall _args                                      \
-{                                                                           \
-    static api_func syscall_func = NULL;                                    \
+TARPC_DECLARE_SYSCALL_WRAPPER_FUNC_BEGIN(, TARPC_LIB_USE_LIBC,              \
+                                         "libc", _name, _rettype,           \
+                                         _args, ##__VA_ARGS__)              \
+TARPC_DECLARE_SYSCALL_WRAPPER_FUNC_END                                      \
                                                                             \
-    if (syscall_func == NULL &&                                             \
-        tarpc_find_func(TARPC_LIB_USE_LIBC, "syscall", &syscall_func) != 0) \
-    {                                                                       \
-        syscall_func = NULL;                                                \
-        ERROR("Failed to find function \"syscall\" in libc");               \
-        return -1;                                                          \
-    }                                                                       \
-    return (_rettype)syscall_func(SYS_##_name, ##__VA_ARGS__);              \
-}                                                                           \
-                                                                            \
-_rettype _name##_te_wrap_syscall_dl _args                                   \
-{                                                                           \
-    static api_func syscall_func = NULL;                                    \
-                                                                            \
-    if (syscall_func == NULL &&                                             \
-        tarpc_find_func(0, "syscall", &syscall_func) != 0)                  \
-    {                                                                       \
-        syscall_func = NULL;                                                \
-        ERROR("Failed to find function \"syscall\" in dynamic lib");        \
-        return -1;                                                          \
-    }                                                                       \
-    return (_rettype)syscall_func(SYS_##_name, ##__VA_ARGS__);              \
-}
+TARPC_DECLARE_SYSCALL_WRAPPER_FUNC_BEGIN(_dl, TARPC_LIB_DEFAULT,            \
+                                         "dynamic lib", _name, _rettype,    \
+                                         _args, ##__VA_ARGS__)              \
+TARPC_DECLARE_SYSCALL_WRAPPER_FUNC_END
 
 /**
  * Type of a hook function called just before FD is closed.

--- a/lib/rpcserver/rpc_server.h
+++ b/lib/rpcserver/rpc_server.h
@@ -1206,6 +1206,33 @@ TARPC_DECLARE_SYSCALL_WRAPPER_FUNC_BEGIN(_dl, TARPC_LIB_DEFAULT,            \
 TARPC_DECLARE_SYSCALL_WRAPPER_FUNC_END
 
 /**
+ * Macro to define syscall function wrapper content that uses sigset_t
+ * argument and needs sizeof(sigset_t) as the last argument in syscall.
+ *
+ * Note we should use the size of the kernel structure which has size
+ * NSIG/8=64/8=8 not 128 that calculated if we just use sizeof(sigset_t).
+ * This wrapper works for supported ppoll, epoll_pwait and epoll_pwait2
+ * functions but shouldn't work for example for pselect6.
+ *
+ * @param _name     Function name (bind, connect, etc.)
+ * @param _rettype  Return type (according to man _name)
+ * @param _args     Arguments list (according to man _name)
+ * @param ...       Values of arguments
+ */
+#define TARPC_SYSCALL_WRAPPER_WITH_SIGSET(_name, _rettype, _args, ...)      \
+TARPC_DECLARE_SYSCALL_WRAPPER_FUNC_BEGIN(, TARPC_LIB_USE_LIBC,              \
+                                         "libc", _name, _rettype,           \
+                                         _args, ##__VA_ARGS__)              \
+                                                             , NSIG / 8     \
+TARPC_DECLARE_SYSCALL_WRAPPER_FUNC_END                                      \
+                                                                            \
+TARPC_DECLARE_SYSCALL_WRAPPER_FUNC_BEGIN(_dl, TARPC_LIB_DEFAULT,            \
+                                         "dynamic lib", _name, _rettype,    \
+                                         _args, ##__VA_ARGS__)              \
+                                                             , NSIG / 8     \
+TARPC_DECLARE_SYSCALL_WRAPPER_FUNC_END
+
+/**
  * Type of a hook function called just before FD is closed.
  *
  * @note Close hooks do not return error directly and closing function

--- a/lib/rpcserver/tarpc_imp.c
+++ b/lib/rpcserver/tarpc_imp.c
@@ -12177,8 +12177,10 @@ TARPC_SYSCALL_WRAPPER(poll, int, (struct pollfd *a, nfds_t b, int c), a, b, c)
 #endif
 
 #ifdef SYS_ppoll
-TARPC_SYSCALL_WRAPPER(ppoll, int, (struct pollfd *a, nfds_t b,
-                      const struct timespec *c, const sigset_t *d), a, b, c, d)
+TARPC_SYSCALL_WRAPPER_WITH_SIGSET(ppoll, int,
+                                  (struct pollfd *a, nfds_t b,
+                                   const struct timespec *c, const sigset_t *d),
+                                  a, b, c, d)
 #endif
 
 #ifdef SYS_splice
@@ -12291,13 +12293,17 @@ TARPC_SYSCALL_WRAPPER(epoll_wait, int, (int a, struct epoll_event *b, int c,
 #endif
 
 #ifdef SYS_epoll_pwait
-TARPC_SYSCALL_WRAPPER(epoll_pwait, int, (int a, struct epoll_event *b, int c,
-                      int d, const sigset_t *e), a, b, c, d, e)
+TARPC_SYSCALL_WRAPPER_WITH_SIGSET(epoll_pwait, int,
+                                  (int a, struct epoll_event *b, int c,
+                                   int d, const sigset_t *e),
+                                  a, b, c, d, e)
 #endif
 
 #ifdef SYS_epoll_pwait2
-TARPC_SYSCALL_WRAPPER(epoll_pwait2, int, (int a, struct epoll_event *b, int c,
-                      struct timespec *d, const sigset_t *e), a, b, c, d, e)
+TARPC_SYSCALL_WRAPPER_WITH_SIGSET(epoll_pwait2, int,
+                                  (int a, struct epoll_event *b, int c,
+                                   struct timespec *d, const sigset_t *e),
+                                  a, b, c, d, e)
 #endif
 
 /**


### PR DESCRIPTION
lib/rpcserver: fix syscall calls to use correct signature
    
Just as it is used in glibc we should add one more argument to syscall
for several syscall callings i.e. ppoll(), epoll_pwait() and
epoll_pwait2(). The additional argument should be sizeof(sigset_t),
however we should use the kernel structure which has size NSIG/8=64/8=8
not 128 that calculated if we just use sizeof(sigset_t) instead.

See    
https://github.com/lattera/glibc/blob/master/sysdeps/unix/sysv/linux/ppoll.c
https://github.com/lattera/glibc/blob/master/sysdeps/unix/sysv/linux/epoll_pwait.c
https://codebrowser.dev/glibc/glibc/sysdeps/unix/sysv/linux/epoll_pwait2.c.html

Testing done:
../cns-sapi-ts/run.sh --ool=syscall --tester-run=sockapi-ts/epoll/create_close_wait:iomux=epoll_pwait
../cns-sapi-ts/run.sh --ool=syscall --tester-run=sockapi-ts/epoll/create_close_wait:iomux=epoll_pwait2
../cns-sapi-ts/run.sh --ool=syscall --tester-run=sockapi-ts/iomux/iomux_sigmask:iomux=ppoll
becomes green
