### PR TITLE
tools/rgt: add expected status to parsing test end message

### DIFF
--- a/tools/rgt/rgt-format/mi_msg.c
+++ b/tools/rgt/rgt-format/mi_msg.c
@@ -1099,6 +1099,7 @@ te_rgt_parse_mi_test_end_message(te_rgt_mi *mi)
                          "obtained", &obtained,
                          "exp_key", &exp_key,
                          "exp_notes", &exp_notes,
+                         "exp_status", &exp_status,
                          "expected", &expected,
                          "tags_expr", &tags_expr,
                          "error", &error);


### PR DESCRIPTION
Foe example for commandline `../cns-sapi-ts/run.sh --tester-run=sockapi-ts/iomux/timeout_update` since cf714d0e70f6 I have got a segfault in the end of the test and no logs in log.txt after prologue and `tree of Instances`. 
```
Done package sockapi-ts fail
--->>> Shutdown Configurator...done
--->>> Flush Logs
--->>> Shutdown RCF...done
--->>> Shutdown Logger...done
--->>> Logs conversion.../home/kosovnn/projects/sapi-ts/cns-sapi-ts/build/inst/default/bin/rgt-proc-raw-log: line 238: 523396 Segmentation fault      "${BINDIR}"/rgt-xml2text -f "${log_xml_merged}" -o "${txt_path}" "${rgt_x2txt_opts[@]}"
done
```
```
RING  prologue  Step  17:56:55.176
Add TRC tags

RING  Configurator  Self  17:56:55.185
tree of Instances /::
...
    /net_pool:ip6/entry:fec0:170:8:: = 0
```

Fixes: cf714d0e70f6 ("engine/tester: save TRC expectations status in MI message")