### PR TITLE
tools/rgt: fix nano multiplier processing in MI graph view

### DIFF
--- a/tools/rgt/rgt-format/xml2html-multi/xml2html-multi.c
+++ b/tools/rgt/rgt-format/xml2html-multi/xml2html-multi.c
@@ -809,7 +809,7 @@ print_mi_meas_param_vals_array(FILE *fd, te_rgt_mi_meas_param *param)
                 }
             }
 
-            fprintf(fd, "%f * %f", value->value, multiplier_value);
+            fprintf(fd, "%f * %.9f", value->value, multiplier_value);
             first_val = false;
         }
     }


### PR DESCRIPTION
Explicitly set precision for multipliers when printing measurement data for JS array. The default precision (6) doesn't work for "1e-9" multipliers. Use 9 instead.

---

Tested by running the selftest and checking html output:
```
./run.sh --cfg=localhost --tester-run=ts/minimal/mi_meas_multipliers --log-html=html
```
Before the patch:
```
<span class="log_h2">Measured parameter: "Nano"</span>
<ul style="list-style-type:none;">
<script>var param_11_0 = [0.000000 * 0.000000, 1.000000 * 0.000000, 2.000000 * 0.000000, 3.000000 * 0.000000, 4.000000 * 0.000000, 5.000000 * 0.000000, 6.000000 * 0.000000, 7.000000 * 0.000000, 8.000000 * 0.000000, 9.000000 * 0.000000];</script><li>
```

After the patch:
```
<span class="log_h2">Measured parameter: "Nano"</span>
<ul style="list-style-type:none;">
<script>var param_11_0 = [0.000000 * 0.000000001, 1.000000 * 0.000000001, 2.000000 * 0.000000001, 3.000000 * 0.000000001, 4.000000 * 0.000000001, 5.000000 * 0.000000001, 6.000000 * 0.000000001, 7.000000 * 0.000000001, 8.000000 * 0.000000001, 9.000000 * 0.000000001];</script><li>
```