### PR TITLE
Some additions for Gtest TAPI

### DIFF
--- a/lib/tapi_gtest/tapi_gtest.c
+++ b/lib/tapi_gtest/tapi_gtest.c
@@ -33,7 +33,9 @@ gtest_build_argv(tapi_gtest *gtest, te_vec *argv)
         TAPI_JOB_OPT_UINT_T("--gtest_random_seed=", true, NULL,
                             tapi_gtest_opts, rand_seed),
         TAPI_JOB_OPT_UINT_T("--verbs_mtu=", true, NULL,
-                            tapi_gtest_opts, verbs_mtu)
+                            tapi_gtest_opts, verbs_mtu),
+        TAPI_JOB_OPT_UINT_T("--completion_wait_multiplier=", true, NULL,
+                            tapi_gtest_opts, compl_wait_mult)
     );
 
     rc = tapi_job_opt_build_args(gtest->bin, opts_binds, opts, argv);

--- a/lib/tapi_gtest/tapi_gtest.c
+++ b/lib/tapi_gtest/tapi_gtest.c
@@ -114,7 +114,17 @@ tapi_gtest_wait(tapi_gtest *gtest, int timeout_ms)
     assert(gtest->group != NULL);
     assert(gtest->impl.job != NULL);
 
-    if ((rc = tapi_job_wait(gtest->impl.job, timeout_ms, &status)) != 0)
+    rc = tapi_job_wait(gtest->impl.job, timeout_ms, &status);
+    if (TE_RC_GET_ERROR(rc) == TE_EINPROGRESS)
+    {
+        rc = tapi_job_kill(gtest->impl.job, SIGINT);
+
+        if (rc == 0)
+            /* Wait 2 ms after killing process */
+            rc = tapi_job_wait(gtest->impl.job, 2, &status);
+    }
+
+    if (rc != 0)
         return rc;
 
     if (status.value == 0 && status.type == TAPI_JOB_STATUS_EXITED)

--- a/lib/tapi_gtest/tapi_gtest.c
+++ b/lib/tapi_gtest/tapi_gtest.c
@@ -48,7 +48,6 @@ te_errno
 tapi_gtest_init(tapi_gtest *gtest, tapi_job_factory_t *factory)
 {
     te_errno rc;
-    te_vec gtest_argv = TE_VEC_INIT(const char *);
     tapi_job_simple_desc_t desc;
     te_string buf = TE_STRING_INIT;
 
@@ -78,16 +77,14 @@ tapi_gtest_init(tapi_gtest *gtest, tapi_job_factory_t *factory)
 
     te_string_append(&buf, "%s.%s", gtest->group, gtest->name);
     gtest->opts.gtest_filter = buf.ptr;
-    if ((rc = gtest_build_argv(gtest, &gtest_argv)) != 0)
-    {
-        te_string_free(&buf);
+    gtest->args = TE_VEC_INIT(const char *);
+    rc = gtest_build_argv(gtest, &gtest->args);
+    if (rc != 0)
         return rc;
-    }
 
-    desc.argv = (const char **) gtest_argv.data.ptr;
+    desc.argv = (const char **) gtest->args.data.ptr;
     rc = tapi_job_simple_create(factory, &desc);
 
-    te_vec_deep_free(&gtest_argv);
     return rc;
 }
 
@@ -169,6 +166,7 @@ tapi_gtest_fini(tapi_gtest *gtest)
     te_errno rc;
     const int term_timeout_ms = -1;
 
+    te_vec_deep_free(&gtest->args);
     if (gtest == NULL || gtest->impl.job == NULL)
         return 0;
 
@@ -176,4 +174,31 @@ tapi_gtest_fini(tapi_gtest *gtest)
         return rc;
 
     return tapi_job_destroy(gtest->impl.job, term_timeout_ms);
+}
+
+te_errno
+tapi_gtest_get_cmd_str(tapi_gtest *gtest, te_string *cmd)
+{
+    char **iter;
+    te_errno rc;
+
+    if (cmd == NULL)
+        return TE_EINVAL;
+
+    te_string_reset(cmd);
+
+    TE_VEC_FOREACH(&(gtest->args), iter)
+    {
+        if (*iter == NULL)
+            break;
+
+        rc = te_string_append(cmd, "%s ", *iter);
+        if (rc != 0)
+        {
+            te_string_free(&cmd);
+            return rc;
+        }
+    }
+
+    return 0;
 }

--- a/lib/tapi_gtest/tapi_gtest.h
+++ b/lib/tapi_gtest/tapi_gtest.h
@@ -43,6 +43,7 @@ typedef struct tapi_gtest_opts {
 
     const char *dev_name;          /**< RDMA device name for GTest */
     tapi_job_opt_uint_t verbs_mtu; /**< MTU for RDMA QP */
+    tapi_job_opt_uint_t compl_wait_mult; /**< Complition timeout multiplier */
 } tapi_gtest_opts;
 
 /** GTest handler */
@@ -58,19 +59,20 @@ typedef struct tapi_gtest {
 } tapi_gtest;
 
 /** Defaults for implementation for GTest handler */
-#define TAPI_GTEST_DEFAULTS (tapi_gtest)       \
-{                                              \
-    .bin = NULL,                               \
-    .group = NULL,                             \
-    .name = NULL,                              \
-    .opts.dev_name = NULL,                     \
-    .opts.run_disabled = false,                \
-    .opts.ipv4_only = false,                   \
-    .opts.no_col = true,                       \
-    .opts.verbs_mtu = TAPI_JOB_OPT_UINT_UNDEF, \
-    .opts.rand_seed = TAPI_JOB_OPT_UINT_UNDEF, \
-    .impl = TAPI_GTEST_IMPL_DEFAULTS,          \
-    .args = {TE_DBUF_INIT(0), 0, NULL},        \
+#define TAPI_GTEST_DEFAULTS (tapi_gtest)             \
+{                                                    \
+    .bin = NULL,                                     \
+    .group = NULL,                                   \
+    .name = NULL,                                    \
+    .opts.dev_name = NULL,                           \
+    .opts.run_disabled = false,                      \
+    .opts.ipv4_only = false,                         \
+    .opts.no_col = true,                             \
+    .opts.compl_wait_mult = TAPI_JOB_OPT_UINT_UNDEF, \
+    .opts.verbs_mtu = TAPI_JOB_OPT_UINT_UNDEF,       \
+    .opts.rand_seed = TAPI_JOB_OPT_UINT_UNDEF,       \
+    .impl = TAPI_GTEST_IMPL_DEFAULTS,                \
+    .args = {TE_DBUF_INIT(0), 0, NULL},              \
 }
 
 /** A way for read gtest option from test arguments */
@@ -79,6 +81,7 @@ typedef struct tapi_gtest {
     .bin = TEST_STRING_PARAM(_gtest##_bin),                               \
     .group = TEST_STRING_PARAM(_gtest##_group),                           \
     .name = TEST_STRING_PARAM(_gtest##_name),                             \
+    .opts.compl_wait_mult = TAPI_JOB_OPT_UINT_UNDEF,                      \
     .opts.verbs_mtu = TAPI_JOB_OPT_UINT_UNDEF,                            \
     .opts.rand_seed = TE_OPTIONAL_UINT_VAL(TEST_INT_PARAM(te_rand_seed)), \
     .opts.ipv4_only = false,                                              \

--- a/lib/tapi_gtest/tapi_gtest.h
+++ b/lib/tapi_gtest/tapi_gtest.h
@@ -53,6 +53,8 @@ typedef struct tapi_gtest {
     tapi_gtest_opts opts;   /**< Options for Gtest binary */
 
     tapi_gtest_impl impl;   /**< Internal implementation struct */
+
+    te_vec args;         /**< Arguments that are used when running the tool. */
 } tapi_gtest;
 
 /** Defaults for implementation for GTest handler */
@@ -68,6 +70,7 @@ typedef struct tapi_gtest {
     .opts.verbs_mtu = TAPI_JOB_OPT_UINT_UNDEF, \
     .opts.rand_seed = TAPI_JOB_OPT_UINT_UNDEF, \
     .impl = TAPI_GTEST_IMPL_DEFAULTS,          \
+    .args = {TE_DBUF_INIT(0), 0, NULL},        \
 }
 
 /** A way for read gtest option from test arguments */
@@ -83,6 +86,7 @@ typedef struct tapi_gtest {
     .opts.no_col = true,                                                  \
     .opts.dev_name = NULL,                                                \
     .impl = TAPI_GTEST_IMPL_DEFAULTS,                                     \
+    .args = {TE_DBUF_INIT(0), 0, NULL},                                   \
 }
 
 /** A way for read gtest option from test arguments */
@@ -135,6 +139,19 @@ extern te_errno tapi_gtest_wait(tapi_gtest *gtest, int timeout_ms);
  * @return Status code
  */
 extern te_errno tapi_gtest_fini(tapi_gtest *gtest);
+
+/**
+ * Get CMD in string representation that will be used to run gtest app.
+ *
+ * @param[in]  gtest        GTest handler
+ * @param[out] cmd          Resulting command line.
+ *
+ * @note It is expected that @p cmd is allocated.
+ *       Can be called only after @b tapi_gtest_init().
+ *
+ * @return Status code.
+ */
+extern te_errno tapi_gtest_get_cmd_str(tapi_gtest *gtest, te_string *cmd);
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
Add the following feature to Gtest TAPI:
1. Add possibility to log Gtest command line
2. Kill Gtest job if it lasts for too long.
3. Add --complition_wait_multiplier option

Tested by running some tests which run Gtest TAPI and job hangs for too long - TAPI now kills such jobs. Also using of "--complition_wait_multiplier " option was added to some tests and they work as expected. And logging of Gtest command line also used in our tests.