### PR TITLE
tad/tad_recv: do not warn about zero len pkt allocation

### DIFF
--- a/lib/tad/eth/tad_tcpip_flood.c
+++ b/lib/tad/eth/tad_tcpip_flood.c
@@ -152,7 +152,7 @@ tad_tcpip_flood(csap_p csap, const char  *usr_param, tad_pkts *pkts)
 #define TCP_SEQ_OFFSET 4
 #define TCP_CHKSUM_OFFSET 16
 
-    rc = tad_pkt_flatten_copy(pkt, &flat_frame, &frame_size);
+    rc = tad_pkt_flatten_copy(pkt, &flat_frame, &frame_size, TRUE);
 
     if (rc != 0)
     {

--- a/lib/tad/tad_pkt.c
+++ b/lib/tad/tad_pkt.c
@@ -596,7 +596,8 @@ tad_pkts_alloc(tad_pkts *pkts, unsigned int n_pkts, unsigned int n_segs,
 
 /* See description in tad_pkt.h */
 te_errno
-tad_pkt_flatten_copy(tad_pkt *pkt, uint8_t **data, size_t *len)
+tad_pkt_flatten_copy(tad_pkt *pkt, uint8_t **data, size_t *len,
+                     te_bool warn_empty_pkt)
 {
     size_t          total_len;
     tad_pkt_seg    *seg;
@@ -609,7 +610,7 @@ tad_pkt_flatten_copy(tad_pkt *pkt, uint8_t **data, size_t *len)
 
     total_len = (len == NULL || *len == 0) ? tad_pkt_len(pkt) : *len;
     if (*data == NULL)
-        *data = TE_ALLOC(total_len);
+        *data = TE_ALLOC((total_len == 0 && !warn_empty_pkt) ? 1 :total_len);
 
     ptr = *data;
     rest_len = total_len;

--- a/lib/tad/tad_pkt.h
+++ b/lib/tad/tad_pkt.h
@@ -354,12 +354,14 @@ extern void tad_pkt_insert_after_seg(tad_pkt *pkt, tad_pkt_seg *seg,
  * Make flatten copy of a packet to specified memory array or to
  * allocated using TE_ALLOC().
  *
- * @param pkt       Packet
- * @param data      Location of the pointer to memory array
- *                  (if *data is NULL, allocate it using TE_ALLOC())
- * @param len       Location of the memory array length or NULL
- *                  (if *data is not NULL, *len is equal to size
- *                  of buffer provided by caller)
+ * @param pkt            Packet
+ * @param data           Location of the pointer to memory array
+ *                       (if *data is NULL, allocate it using TE_ALLOC())
+ * @param len            Location of the memory array length or NULL
+ *                       (if *data is not NULL, *len is equal to size
+ *                       of buffer provided by caller)
+ * @param warn_empty_pkt Should we warn about attempt to allocate zero buffer
+ *                       for the packet if it has zero length
  *
  * If buffer provided by caller is not sufficient, the buffer is filled
  * in and TE_ESMALLBUF is returned.
@@ -367,7 +369,8 @@ extern void tad_pkt_insert_after_seg(tad_pkt *pkt, tad_pkt_seg *seg,
  * @return Status code.
  */
 extern te_errno tad_pkt_flatten_copy(tad_pkt *pkt,
-                                     uint8_t **data, size_t *len);
+                                     uint8_t **data, size_t *len,
+                                     te_bool warn_useless_empty_pkt);
 
 /**
  * Get the first segment of the packet.

--- a/lib/tad/tad_recv.c
+++ b/lib/tad/tad_recv.c
@@ -730,7 +730,7 @@ tad_recv_do_action(csap_p csap, tad_action_spec *action_spec,
                 size_t      raw_len = 0;
 
                 rc = tad_pkt_flatten_copy(tad_pkts_first_pkt(low_pkts),
-                                          &raw_pkt, &raw_len);
+                                          &raw_pkt, &raw_len, TRUE);
                 if (rc != 0)
                 {
                     ERROR(CSAP_LOG_FMT "Failed to make flatten copy "
@@ -1541,7 +1541,7 @@ tad_recv_get_packets(csap_p csap, tad_reply_context *reply_ctx, bool wait,
         if (~csap->state & CSAP_STATE_PACKETS_NO_PAYLOAD)
         {
             rc = tad_pkt_flatten_copy(&pkt->payload,
-                                      &payload, &payload_len);
+                                      &payload, &payload_len, FALSE);
             if (rc != 0)
             {
                 ERROR(CSAP_LOG_FMT "Failed to make flatten copy of "


### PR DESCRIPTION
If packet payload has zero length (for example for ACK or SYN
for vlan) and we need to allocate memory for it there was a warning
about attempt to allocate a zero buffer.

AMD-Jira-ID: ST-2756

Testing done:
```
../cns-sapi-ts/run.sh --cfg=...  --ool=vlan --tester-run=sockapi-ts/tcp/listen_backlog_max
```
There is no warnings `Attempted to allocate a zero buffer`

I'm not sure may be I should switch off this warnings always in `tad_pkt_flatten_copy()`. But I'm sure it should be switched off in this case. I didn't switched off the warnings in other cases as it was previously.