### PR TITLE
agents/unix: do not set RSS hash key if resetting

### DIFF
--- a/agents/unix/conf/base/conf_ethtool.c
+++ b/agents/unix/conf/base/conf_ethtool.c
@@ -880,6 +880,7 @@ ta_ethtool_get_rssh(unsigned int gid, const char *if_name,
     result->rxfh = got_rxfh;
     result->indir_change = false;
     result->indir_reset = false;
+    result->hash_key_change = false;
 
     rc = ta_obj_add(TA_OBJ_TYPE_IF_RSSH, te_string_value(&obj_name),
                     "", gid, result, &free_ta_ethtool_rxfh, &obj);
@@ -931,6 +932,8 @@ ta_ethtool_commit_rssh(unsigned int gid, const char *if_name,
     if (ta_rxfh->indir_reset)
     {
         ta_rxfh->rxfh->indir_size = 0;
+        if (!ta_rxfh->hash_key_change)
+            ta_rxfh->rxfh->key_size = 0;
         remove_indir_data = true;
     }
 

--- a/agents/unix/conf/base/conf_ethtool.h
+++ b/agents/unix/conf/base/conf_ethtool.h
@@ -445,6 +445,8 @@ typedef struct ta_ethtool_rxfh {
     bool indir_change;
     /** If @c true, reset indirection table to default values. */
     bool indir_reset;
+    /** Should be set to @c true if change of RSS hash key is required. */
+    bool hash_key_change;
 } ta_ethtool_rxfh;
 
 /**

--- a/agents/unix/conf/base/conf_rss.c
+++ b/agents/unix/conf/base/conf_rss.c
@@ -137,6 +137,7 @@ hash_key_set(unsigned int gid, const char *oid,
     if (rc != 0)
         return rc;
 
+    rxfh->hash_key_change = true;
     return te_str_hex_str2raw(value, RSS_HASH_KEY(rxfh->rxfh),
                               rxfh->rxfh->key_size);
 #endif


### PR DESCRIPTION
Setting the hash key is an unrelated operation that may cause failures with some drivers, e.g. ENA.

Bring the behaviour closer to what "ethtool -X ... default" does.

Reviewed-by: Sergey Nikitin <sergey.nikitin@oktet.tech>

Testing done: tested on a configuration with ENA network interfaces, setting the "/agent/interface/rss/context/hash_indir/indir_default" object instance does not cause any errors anymore