### PR TITLE
dispatcher.sh: allow running scripts before shutdown

### DIFF
--- a/dispatcher.sh
+++ b/dispatcher.sh
@@ -178,6 +178,8 @@ Generic options:
 
   --script=<filename>           Name of the file with shell script to be
                                 included as source
+  --tester-script=<filename>    Name of the file with shell script to be
+                                included as source before starting Tester
 
   --live-log                    Run RGT in live mode
 

--- a/dispatcher.sh
+++ b/dispatcher.sh
@@ -60,6 +60,22 @@ TESTER_RC=0
 TESTER_INTR_RC=2
 
 #####################################################
+# Perform post-run operations: finalize metadata and
+# call user-specified scripts.
+#####################################################
+exit_handler() {
+    if [[ "${TE_RUN_META}" = "yes" ]] ; then
+        finish_metadata trap
+    fi
+
+    for i in "${TE_FINISH_SCRIPTS[@]}" ; do
+        script_opts=
+        run_script $i
+    done
+}
+trap "exit_handler" EXIT
+
+#####################################################
 # Finish metadata file.
 # Arguments:
 #   Status (0 - success, nonzero - failure; if the
@@ -140,8 +156,6 @@ if [[ "${TE_RUN_META}" = "yes" ]] ; then
     fi
 
     te_meta_export
-
-    trap "finish_metadata trap" EXIT
 fi
 
 usage()
@@ -180,6 +194,8 @@ Generic options:
                                 included as source
   --tester-script=<filename>    Name of the file with shell script to be
                                 included as source before starting Tester
+  --finish-script=<filename>    Name of the file with shell script to be
+                                included as source right before exiting
 
   --live-log                    Run RGT in live mode
 
@@ -564,6 +580,7 @@ TE_PUBLISH_SCRIPT=
 LOGGER_META_FILE=
 
 declare -a TE_TESTER_SCRIPTS
+declare -a TE_FINISH_SCRIPTS
 export TE_TA_LIST_FILE=ta.list
 
 resolve_conf_file_path()
@@ -659,6 +676,11 @@ process_opts()
             --tester-script=* )
                 process_script_opt $1 tester-script
                 TE_TESTER_SCRIPTS+=("${script_file}")
+                ;;
+
+            --finish-script=* )
+                process_script_opt $1 finish-script
+                TE_FINISH_SCRIPTS+=("${script_file}")
                 ;;
 
 

--- a/dispatcher.sh
+++ b/dispatcher.sh
@@ -563,7 +563,7 @@ TE_PUBLISH_SCRIPT=
 # File passed with --logger-meta-file option
 LOGGER_META_FILE=
 
-TE_TESTER_SCRIPTS=
+declare -a TE_TESTER_SCRIPTS
 export TE_TA_LIST_FILE=ta.list
 
 resolve_conf_file_path()
@@ -658,7 +658,7 @@ process_opts()
 
             --tester-script=* )
                 process_script_opt $1 tester-script
-                TE_TESTER_SCRIPTS="${TE_TESTER_SCRIPTS} ${script_file}"
+                TE_TESTER_SCRIPTS+=("${script_file}")
                 ;;
 
 
@@ -1404,7 +1404,7 @@ else
     CS_OK=yes
 fi
 
-for i in ${TE_TESTER_SCRIPTS} ; do
+for i in "${TE_TESTER_SCRIPTS[@]}" ; do
     script_opts=
     run_script $i
 done


### PR DESCRIPTION
Implement a new CLI parameter for specifying which scripts need to be run after the tests have finished.

This functionality is required for configurations that need to perform some non-trivial cleanup.

Reviewed-by: Sergey Nikitin <sergey.nikitin@oktet.tech>

Testing done: tested in a cloud environment where agent hosts are automatically created and destroyed