### PR TITLE
engine/tester: allow to override package description

### DIFF
--- a/doc/xsd/tester_defs.xsd
+++ b/doc/xsd/tester_defs.xsd
@@ -776,6 +776,15 @@
                 </xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
+        <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:element name="objective" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        Objective of the test package.
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:choice>
     </xsd:complexType>
 
 <!--


### PR DESCRIPTION
The package may have arguments. Depending on these arguments, the package description may change. This patch allows to have an objective inside "package" node.