### PR TITLE
scripts/te_meta_gen: use env in shebang for python

### DIFF
--- a/scripts/te_meta_gen
+++ b/scripts/te_meta_gen
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2023 OKTET Labs Ltd. All rights reserved.
 """Script generating testing metadata in JSON format."""


### PR DESCRIPTION
Changed the shebang from '#!/usr/bin/python3' to '#!/usr/bin/env python3' to ensure the script uses the Python interpreter found in the system's PATH, making it more flexible and portable across different environments.

On old RHEL7 python3 could be in other place rather then /usr/bin/.