### PR TITLE
lib/rcfpch: add function to get RPC server PID

### DIFF
--- a/lib/rcfpch/rcf_pch_internal.h
+++ b/lib/rcfpch/rcf_pch_internal.h
@@ -151,6 +151,15 @@ extern struct rpcserver *rcf_pch_rpcserver_next(struct rpcserver *rpcs);
 extern const char *rcf_pch_rpcserver_get_name(const struct rpcserver *rpcs);
 
 /**
+ * Get the pid of RPC server.
+ *
+ * @param rpcs  RPC server
+ *
+ * @return      the pid of RPC server
+ */
+extern pid_t rcf_pch_rpcserver_get_pid(const struct rpcserver *rpcs);
+
+/**
  * Add the node rpcserver_plugin in configuration tree,
  * initialize the mutex and the RPC call.
  *

--- a/lib/rcfpch/rcf_pch_rpc.c
+++ b/lib/rcfpch/rcf_pch_rpc.c
@@ -2000,3 +2000,9 @@ rcf_pch_rpcserver_get_name(const rpcserver *rpcs)
 {
     return rpcs->name;
 }
+
+pid_t
+rcf_pch_rpcserver_get_pid(const rpcserver *rpcs)
+{
+    return rpcs->pid;
+}


### PR DESCRIPTION
In some test suite we need to find RPC server by name and send appropriate signal to it from Configurator, so we need also it's PID.