### PR TITLE
tapi_rpc/tapi_rpcsock_macros: fix using string copying func

### DIFF
--- a/lib/tapi_rpc/tapi_rpcsock_macros.h
+++ b/lib/tapi_rpc/tapi_rpcsock_macros.h
@@ -440,8 +440,8 @@
         char  path_name[RCF_MAX_PATH] = "/tmp/";                        \
                                                                         \
         position = path_name + strlen(path_name);                       \
-        position = te_strlcpy(position, file_name_,                     \
-                              sizeof(path_name) - strlen(path_name));   \
+        te_strlcpy(position, file_name_,                                \
+                   sizeof(path_name) - strlen(path_name));              \
         (recv_) = rpc_socket_to_file((rpcs_), (sockd_),                 \
                                       path_name, (timeout_));           \
     } while (0)


### PR DESCRIPTION
te_strlcpy() does not return the string but the length of the string. Therefore it is not a good idea to assign the length to the string. This error makes impossible to build SAPI-TS on Debian 13.

Fixes: afaada7087af ("Import the first public release")

With some additional SAPI-TS patches i.e. https://github.com/Xilinx-CNS/cns-sapi-ts/pull/130 it makes possible to build SAPI-TS on Debian 13 without errors.