### PR TITLE
User/okt kosovnn/fix pattern receiver

### DIFF
--- a/lib/rpcserver/tarpc_imp.c
+++ b/lib/rpcserver/tarpc_imp.c
@@ -8565,7 +8565,7 @@ pattern_receiver(tarpc_pattern_receiver_in *in,
             }
             else if (rc > 1)
             {
-                te_rpc_error_set(TE_RC(TE_TA_UNIX, TE_EINVAL),
+                te_rpc_error_set(TE_RC(TE_RPC, TE_EINVAL),
                                  "%s(): iomux function returned more then "
                                  "one fd", __FUNCTION__);
                 PTRN_RECV_ERROR;
@@ -8581,7 +8581,7 @@ pattern_receiver(tarpc_pattern_receiver_in *in,
                 ERROR("%s(): %s wait returned incorrect fd %d instead of %d",
                       __FUNCTION__, iomux2str(iomux), fd, in->s);
 
-                te_rpc_error_set(TE_RC(TE_TA_UNIX, TE_EINVAL),
+                te_rpc_error_set(TE_RC(TE_RPC, TE_EINVAL),
                                  "%s(): iomux function returned incorrect "
                                  "fd", __FUNCTION__);
                 PTRN_RECV_ERROR;
@@ -8604,7 +8604,7 @@ pattern_receiver(tarpc_pattern_receiver_in *in,
                       "not readable, reported events 0x%x", __FUNCTION__,
                       iomux2str(iomux), events);
 
-                te_rpc_error_set(TE_RC(TE_TA_UNIX, TE_EINVAL),
+                te_rpc_error_set(TE_RC(TE_RPC, TE_EINVAL),
                                  "%s(): iomux function returned unexpected "
                                  "events instead of POLLIN", __FUNCTION__);
 
@@ -8635,7 +8635,7 @@ pattern_receiver(tarpc_pattern_receiver_in *in,
             {
                 ERROR("%s(): failed to generate a pattern", __FUNCTION__);
 
-                te_rpc_error_set(TE_RC(TE_TA_UNIX, TE_EINVAL),
+                te_rpc_error_set(TE_RC(TE_RPC, TE_EINVAL),
                                  "%s(): failed to generate data according "
                                  "to the pattern", __FUNCTION__);
                 PTRN_RECV_ERROR;
@@ -8645,7 +8645,7 @@ pattern_receiver(tarpc_pattern_receiver_in *in,
             {
                 LOG_HEX_DIFF_DUMP(TE_LL_WARN, check_buf + offset, buf, len);
 
-                te_rpc_error_set(TE_RC(TE_TA_UNIX, TE_EINVAL),
+                te_rpc_error_set(TE_RC(TE_RPC, TE_EINVAL),
                                  "%s(): received data does not match the "
                                  "pattern", __FUNCTION__);
                 iomux_close(iomux, &iomux_f, &iomux_st);

--- a/lib/tapi_rpc/misc.c
+++ b/lib/tapi_rpc/misc.c
@@ -847,8 +847,9 @@ rpc_pattern_receiver(rcf_rpc_server *rpcs, int s,
     if (args->recv_failed_ptr != NULL)
         *(args->recv_failed_ptr) = out.func_failed;
 
-    CHECK_RETVAL_VAR(pattern_receiver, out.retval,
-                     !(out.retval <= 0 && out.retval >= -2), -1);
+    CHECK_RETVAL_VAR_ERR_COND(pattern_receiver, out.retval,
+                              !(out.retval <= 0 && out.retval >= -2), -1,
+                              (out.retval == -1 || out.retval == -2));
 
     TAPI_RPC_LOG(rpcs, pattern_receiver, "fd=%d, gen_func='%s', "
                  "gen_arg=[" TARPC_PAT_GEN_ARG_FMT "], iomux='%s', "

--- a/lib/tapi_rpc/tapi_rpc_misc.h
+++ b/lib/tapi_rpc/tapi_rpc_misc.h
@@ -472,7 +472,7 @@ extern int rpc_pattern_sender(rcf_rpc_server *rpcs, int s,
  * @param args            Pointer to @ref tapi_pat_receiver structure.
  *
  * @return Status code.
- * @retval >= 0   number of received bytes
+ * @retval 0      success
  * @retval -2     data doesn't match the pattern
  * @retval -1     in the case of another failure
  */


### PR DESCRIPTION
It seems like there was some mistakes in rpc_pattern_receiver() that should be corrected.
For example previously there can be some stange rc in log like
```
RPC (Agt_A,pco_iut[6]) wait: pattern_receiver(fd=6, gen_func='tarpc_fill_buff_with_sequence_lcg', gen_arg=[0, 113799198, 1221676573, 1365346365], iomux='default iomux', time2wait=500, duration_sec=9, ignore_pollerr=FALSE) -> -1 received=116896500 (TA_UNIX-EINVAL (error message 'pattern_receiver(): received data does not match the pattern'))
```
Now in this case we obtain -2 not -1.