### PR TITLE
lib/tapi: add missing value handler for te_bool3

### DIFF
--- a/lib/tapi/tapi_test.h
+++ b/lib/tapi/tapi_test.h
@@ -1624,6 +1624,23 @@ extern te_optional_double_t test_get_opt_value_unit_param(int argc,
                                                           const char *name);
 
 /**
+ * Get optional boolean value of type #te_bool3 from arguments.
+ *
+ * @note Allows to specify "missing" value by providing literal @c - .
+ * This literal is replaced with #TE_BOOL3_UNKNOWN.
+ *
+ * @param argc       count of arguments
+ * @param argv       list of arguments
+ * @param name       name of parameter
+ *
+ * @return optional boolean value
+ *
+ * @sa te_bool3
+ */
+extern te_bool3 test_get_opt_bool3_param(int argc, char **argv,
+                                         const char *name);
+
+/**
  * Same as test_get_value_bin_unit_param() but the return type is optional.
  *
  * @param argc       count of arguments
@@ -1758,6 +1775,32 @@ extern te_optional_uintmax_t test_get_opt_value_bin_unit_param(
  */
 #define TEST_GET_OPT_VALUE_BIN_UNIT_PARAM(var_name_) \
     (var_name_) = TEST_OPT_VALUE_BIN_UNIT_PARAM(var_name_)
+
+/**
+ * The macro to return optional parameter of type #te_bool3.
+ *
+ * @note Allows to specify "missing" value by providing literal @c - .
+ * This literal is replaced with #TE_BOOL3_UNKNOWN.
+ *
+ * @param var_name_  variable with the same name as the name of
+ *                   the desired parameter
+ *
+ * @return te_bool3 value
+ */
+#define TEST_OPT_BOOL3_PARAM(var_name_)                                        \
+    test_get_opt_bool3_param(argc, argv, #var_name_)
+
+/**
+ * The macro to get optional parameter of type #te_bool3.
+ *
+ * @note Allows to specify "missing" value by providing literal @c - .
+ * This literal is replaced with #TE_BOOL3_UNKNOWN.
+ *
+ * @param var_name_  variable with the same name as the name of
+ *                   the desired parameter
+ */
+#define TEST_GET_OPT_BOOL3_PARAM(var_name_)                                    \
+    (var_name_) = TEST_OPT_BOOL3_PARAM(var_name_)
 
 /**@}*/
 

--- a/lib/tapi/test_params.c
+++ b/lib/tapi/test_params.c
@@ -1422,3 +1422,14 @@ test_get_opt_value_bin_unit_param(int argc, char **argv, const char *name)
     return TE_OPTIONAL_UINTMAX_VAL(
         test_get_value_bin_unit_param(argc, argv, name));
 }
+
+te_bool3
+test_get_opt_bool3_param(int argc, char **argv, const char *name)
+{
+    if (is_opt_param_none(argc, argv, name))
+        return TE_BOOL3_UNKNOWN;
+
+    return test_get_enum_param(
+        argc, argv, name,
+        (struct param_map_entry[]){BOOL3_MAPPING_LIST, {NULL, 0}});
+}

--- a/suites/selftest/conf/trc/minimal.trc.xml
+++ b/suites/selftest/conf/trc/minimal.trc.xml
@@ -93,6 +93,9 @@
                 <arg name="opt_unit_val_param" />
                 <arg name="opt_bin_unit_none_param" />
                 <arg name="opt_bin_unit_val_param" />
+                <arg name="opt_bool_none_param" />
+                <arg name="opt_bool_false_param" />
+                <arg name="opt_bool_true_param" />
                 <arg name="good_result" />
                 <arg name="good_result_noprefix" />
                 <arg name="good_int_result" />

--- a/suites/selftest/ts/minimal/package.xml
+++ b/suites/selftest/ts/minimal/package.xml
@@ -122,6 +122,15 @@
             <arg name="opt_bin_unit_val_param">
                 <value>1M</value>
             </arg>
+            <arg name="opt_bool_none_param">
+                <value>-</value>
+            </arg>
+            <arg name="opt_bool_false_param">
+                <value>FALSE</value>
+            </arg>
+            <arg name="opt_bool_true_param">
+                <value>TRUE</value>
+            </arg>
             <arg name="good_result">
                 <value>OK:value</value>
             </arg>

--- a/suites/selftest/ts/minimal/parameters.c
+++ b/suites/selftest/ts/minimal/parameters.c
@@ -21,6 +21,12 @@
 #include "te_config.h"
 #include "tapi_test.h"
 
+static const te_enum_map opt_bool_map[] = {
+    {.name = "TE_BOOL3_FALSE", .value = TE_BOOL3_FALSE},
+    {.name = "TE_BOOL3_UNKNOWN", .value = TE_BOOL3_UNKNOWN},
+    {.name = "TE_BOOL3_TRUE", .value = TE_BOOL3_TRUE},
+    TE_ENUM_MAP_END};
+
 int
 main(int argc, char **argv)
 {
@@ -49,6 +55,9 @@ main(int argc, char **argv)
     te_optional_double_t opt_unit_val_param = TE_OPTIONAL_DOUBLE_UNDEF;
     te_optional_uintmax_t opt_bin_unit_none_param = TE_OPTIONAL_UINTMAX_VAL(0);
     te_optional_uintmax_t opt_bin_unit_val_param = TE_OPTIONAL_UINTMAX_UNDEF;
+    te_bool3 opt_bool_none_param = TE_BOOL3_FALSE;
+    te_bool3 opt_bool_false_param = TE_BOOL3_UNKNOWN;
+    te_bool3 opt_bool_true_param = TE_BOOL3_UNKNOWN;
     tapi_test_expected_result good_result;
     tapi_test_expected_result good_result_noprefix;
     tapi_test_expected_result good_int_result;
@@ -84,6 +93,9 @@ main(int argc, char **argv)
     TEST_GET_OPT_VALUE_UNIT_PARAM(opt_unit_val_param);
     TEST_GET_OPT_VALUE_BIN_UNIT_PARAM(opt_bin_unit_none_param);
     TEST_GET_OPT_VALUE_BIN_UNIT_PARAM(opt_bin_unit_val_param);
+    TEST_GET_OPT_BOOL3_PARAM(opt_bool_none_param);
+    TEST_GET_OPT_BOOL3_PARAM(opt_bool_false_param);
+    TEST_GET_OPT_BOOL3_PARAM(opt_bool_true_param);
 
     TEST_STEP("Getting expected result parameters");
     TEST_GET_EXPECTED_RESULT_PARAM(good_result);
@@ -161,6 +173,21 @@ main(int argc, char **argv)
     CHECK_OPTNUMERIC_PARAMS(opt_bin_unit_none_param, opt_bin_unit_val_param,
                             1ull << 20, "%ju");
 #undef CHECK_OPTNUMERIC_PARAMS
+
+#define CHECK_OPTBOOL3_PARAM(_name, _expected)                                 \
+    do {                                                                       \
+        if ((_name) != (_expected))                                            \
+        {                                                                      \
+            TEST_VERDICT(                                                      \
+                "'%s' has unexpected value: %s", #_name,                       \
+                te_enum_map_from_any_value(opt_bool_map, (_name), "INVALID")); \
+        }                                                                      \
+    } while (0)
+
+    CHECK_OPTBOOL3_PARAM(opt_bool_none_param, TE_BOOL3_UNKNOWN);
+    CHECK_OPTBOOL3_PARAM(opt_bool_false_param, TE_BOOL3_FALSE);
+    CHECK_OPTBOOL3_PARAM(opt_bool_true_param, TE_BOOL3_TRUE);
+#undef CHECK_OPTBOOL3_PARAM
 
     TEST_STEP("Checking expected results");
 #define CHECK_EXPECTED(_var, _rc, _value) \


### PR DESCRIPTION
Tested with testsuite and minimal selftest.
`TS_BASE=${TE_BASE}/suites/selftest/ts ./run.sh --tester-run=ts/minimal --cfg=localhost --log-html=html`