### PR TITLE
lib/agentlib: add funcs to get cmd output on TA as TE string

### DIFF
--- a/lib/agentlib/agentlib.h
+++ b/lib/agentlib/agentlib.h
@@ -17,6 +17,7 @@
 #endif
 
 #include "tq_string.h"
+#include "te_string.h"
 
 /**
  * Get parent device name of VLAN interface.
@@ -371,5 +372,17 @@ extern te_errno agent_key_generate(agent_key_manager manager,
                                    unsigned bitsize,
                                    const char *user,
                                    const char *private_key_file);
+
+/**
+ * Add output of command on TA to te_string string.
+ *
+ * @param[in,out] str    String to add output.
+ * @param[in]     cmd    Command format string.
+ * @param[in]     ...    Format string arguments.
+ *
+ * @return Status code.
+ */
+extern te_errno ta_read_cmd_fmt(te_string *str, const char *cmd, ...)
+                                TE_LIKE_PRINTF(2, 3);
 
 #endif /* __TE_AGENTLIB_H__ */


### PR DESCRIPTION
```
../cns-sapi-ts/run.sh --cfg=... --ool=onload --ool=no_reuse_pco --tester-run=sockapi-ts/tcp/tcp_handle_fin
```
looks good with https://github.com/Xilinx-CNS/cns-sapi-ts/pull/133 and commenting out the introduced function ta_read_cmd() in SAPI-TS
```
Author: Nikolai Kosovskii <Nikolai.Kosovskii@arknetworks.am>
Date:   Fri Dec 5 14:25:59 2025 +0400

    remove ta_read_cmd

diff --git a/talib_sockapi_ts/parse_orm_json.c b/talib_sockapi_ts/parse_orm_json.c
index 9fb0310..0572f3e 100644
--- a/talib_sockapi_ts/parse_orm_json.c
+++ b/talib_sockapi_ts/parse_orm_json.c
@@ -104,6 +104,7 @@ rpc_tcp_state ci_tcp_state_2_rpc_tcp_state(int state_i)
   return state_strs[state_i];
 }
 
+#if 0
 /* See the description in parse_orm_json.h */
 te_errno
 ta_read_cmd(const char *cmd, te_string *str)
@@ -156,6 +157,7 @@ cleanup:
     return rc;
 }
 
+#endif
 /**
  * Check if struct sockaddr address @p addr has provided IP address and port.
  * Port is checked only if @p check_port is @c TRUE.
diff --git a/talib_sockapi_ts/parse_orm_json.h b/talib_sockapi_ts/parse_orm_json.h
index 92795dc..46a8763 100644
--- a/talib_sockapi_ts/parse_orm_json.h
+++ b/talib_sockapi_ts/parse_orm_json.h
@@ -48,6 +48,7 @@ rpc_tcp_state ci_tcp_state_2_rpc_tcp_state(int state_i);
 #define orm_json_tcp_state_2_rpc_tcp_state(_i) \
     ci_tcp_state_2_rpc_tcp_state(CI_TCP_STATE_NUM(_i))
 
+#if 0
 /**
  * Get output of command on TA in te_string representation
  *
@@ -58,6 +59,7 @@ rpc_tcp_state ci_tcp_state_2_rpc_tcp_state(int state_i);
  */
 te_errno ta_read_cmd(const char *cmd, te_string *str);
 
+#endif
 /**
  * Get TCP state from an orm_json tool's output.
```