### PR TITLE
Make large MI measurement logs more compact

### DIFF
--- a/doc/drafts/mi-schema.json
+++ b/doc/drafts/mi-schema.json
@@ -92,10 +92,11 @@
       "type": "object",
       "properties": {
         "aggr": {
-          "description": "Statistical aggregation (except single), see 'meas_aggr_names'",
+          "description": "Statistical aggregation (except single and series), see 'meas_aggr_names'",
           "type": "string",
           "enum": [
             "single",
+            "series",
             "min",
             "max",
             "mean",

--- a/lib/tools/te_json.c
+++ b/lib/tools/te_json.c
@@ -245,6 +245,18 @@ te_json_add_array_str(te_json_ctx_t *ctx, bool skip_null,
 }
 
 void
+te_json_add_array_float(te_json_ctx_t *ctx, size_t n_vals,
+                        const double vals[n_vals], int precision)
+{
+    size_t i;
+
+    te_json_start_array(ctx);
+    for (i = 0; i < n_vals; i++)
+        te_json_add_float(ctx, vals[i], precision);
+    te_json_end(ctx);
+}
+
+void
 te_json_add_kvpair(te_json_ctx_t *ctx, const te_kvpair_h *head)
 {
     te_kvpair *p;

--- a/lib/tools/te_json.h
+++ b/lib/tools/te_json.h
@@ -366,6 +366,17 @@ extern void te_json_add_array_str(te_json_ctx_t *ctx, bool skip_null,
                                   size_t n_strs, const char *strs[n_strs]);
 
 /**
+ * Serialize an array of floats.
+ *
+ * @param ctx           JSON context.
+ * @param n_vals        Number of elements in @p strs.
+ * @param vals          Array of strings.
+ * @param precision     Floating-point precision (unlimited if negative).
+ */
+extern void te_json_add_array_float(te_json_ctx_t *ctx, size_t n_vals,
+                                    const double vals[n_vals], int precision);
+
+/**
  * Serialize a list of kv_pairs as a JSON object.
  *
  * @param ctx  JSON context

--- a/lib/tools/te_mi_log.c
+++ b/lib/tools/te_mi_log.c
@@ -37,6 +37,7 @@ typedef struct te_mi_meas_value {
     te_mi_meas_aggr aggr;
     double val;
     te_mi_meas_multiplier multiplier;
+    const char *base_units;
 } te_mi_meas_value;
 
 typedef TAILQ_HEAD(te_mi_meas_value_h, te_mi_meas_value) te_mi_meas_value_h;
@@ -309,7 +310,8 @@ te_mi_meas_value_str_append(const te_mi_meas_value *value, te_mi_meas_type type,
     te_json_add_float(ctx, value->val, 6);
 
     te_json_add_key_str(ctx, "base_units",
-                        te_mi_meas_get_base_unit_str(type, value->aggr));
+                        value->base_units != NULL ? value->base_units :
+                            te_mi_meas_get_base_unit_str(type, value->aggr));
 
     te_json_add_key_enum(ctx, meas_multiplier_names, "multiplier",
                          value->multiplier);
@@ -514,7 +516,8 @@ te_mi_logger_data2str(const te_mi_logger *logger)
 
 static te_mi_meas_value *
 te_mi_meas_value_add(te_mi_meas_value_h *values, te_mi_meas_aggr aggr,
-                     double val, te_mi_meas_multiplier multiplier)
+                     double val, te_mi_meas_multiplier multiplier,
+                     const char *base_units)
 {
     te_mi_meas_value *result;
 
@@ -523,6 +526,7 @@ te_mi_meas_value_add(te_mi_meas_value_h *values, te_mi_meas_aggr aggr,
     result->aggr = aggr;
     result->val = val;
     result->multiplier = multiplier;
+    result->base_units = base_units;
     TAILQ_INSERT_TAIL(values, result, next);
 
     return result;
@@ -1290,6 +1294,17 @@ te_mi_logger_add_meas(te_mi_logger *logger, te_errno *retval,
                       te_mi_meas_aggr aggr, double val,
                       te_mi_meas_multiplier multiplier)
 {
+    te_mi_logger_add_meas_units(logger, retval, type, name, aggr, val,
+                                multiplier, NULL);
+}
+
+void
+te_mi_logger_add_meas_units(te_mi_logger *logger, te_errno *retval,
+                            te_mi_meas_type type, const char *name,
+                            te_mi_meas_aggr aggr, double val,
+                            te_mi_meas_multiplier multiplier,
+                            const char *base_units)
+{
     te_mi_meas_impl *meas;
     te_errno rc = 0;
 
@@ -1333,7 +1348,7 @@ te_mi_logger_add_meas(te_mi_logger *logger, te_errno *retval,
     if (meas == NULL)
         meas = te_mi_meas_impl_add(&logger->meas_q, type, name);
 
-    te_mi_meas_value_add(&meas->values, aggr, val, multiplier);
+    te_mi_meas_value_add(&meas->values, aggr, val, multiplier, base_units);
 
 out:
     te_mi_set_logger_error(logger, retval, rc);
@@ -1351,8 +1366,9 @@ te_mi_logger_add_meas_obj(te_mi_logger *logger, te_errno *retval,
         return;
     }
 
-   te_mi_logger_add_meas(logger, retval, meas->type, meas->name, meas->aggr,
-                          meas->val, meas->multiplier);
+   te_mi_logger_add_meas_units(logger, retval, meas->type, meas->name,
+                               meas->aggr, meas->val, meas->multiplier,
+                               meas->base_units);
 }
 
 void

--- a/lib/tools/te_mi_log.c
+++ b/lib/tools/te_mi_log.c
@@ -36,6 +36,8 @@ typedef struct te_mi_meas_value {
     TAILQ_ENTRY(te_mi_meas_value) next;
     te_mi_meas_aggr aggr;
     double val;
+    size_t n_vals;
+    double *vals;
     te_mi_meas_multiplier multiplier;
     const char *base_units;
 } te_mi_meas_value;
@@ -157,6 +159,7 @@ static const te_enum_map mi_type_names[] = {
 
 static const te_enum_map meas_aggr_names[] = {
     {.value = TE_MI_MEAS_AGGR_SINGLE, .name = "single"},
+    {.value = TE_MI_MEAS_AGGR_SERIES, .name = "series"},
     {.value = TE_MI_MEAS_AGGR_MIN, .name = "min"},
     {.value = TE_MI_MEAS_AGGR_MAX, .name = "max"},
     {.value = TE_MI_MEAS_AGGR_MEAN, .name = "mean"},
@@ -306,8 +309,16 @@ te_mi_meas_value_str_append(const te_mi_meas_value *value, te_mi_meas_type type,
     te_json_start_object(ctx);
     te_json_add_key_enum(ctx, meas_aggr_names, "aggr", value->aggr);
 
-    te_json_add_key(ctx, "value");
-    te_json_add_float(ctx, value->val, 6);
+    if (value->vals != NULL)
+    {
+        te_json_add_key(ctx, "values");
+        te_json_add_array_float(ctx, value->n_vals, value->vals, 6);
+    }
+    else
+    {
+        te_json_add_key(ctx, "value");
+        te_json_add_float(ctx, value->val, 6);
+    }
 
     te_json_add_key_str(ctx, "base_units",
                         value->base_units != NULL ? value->base_units :
@@ -525,6 +536,28 @@ te_mi_meas_value_add(te_mi_meas_value_h *values, te_mi_meas_aggr aggr,
 
     result->aggr = aggr;
     result->val = val;
+    result->multiplier = multiplier;
+    result->base_units = base_units;
+    TAILQ_INSERT_TAIL(values, result, next);
+
+    return result;
+}
+
+static te_mi_meas_value *
+te_mi_meas_values_add(te_mi_meas_value_h *values, te_mi_meas_aggr aggr,
+                      size_t n_vals, const double *vals,
+                      te_mi_meas_multiplier multiplier, const char *base_units)
+{
+    te_mi_meas_value *result;
+
+    result = TE_ALLOC(sizeof(*result));
+
+    result->aggr = aggr;
+
+    result->n_vals = n_vals;
+    result->vals = calloc(n_vals, sizeof(double));
+    memcpy(result->vals, vals, n_vals * sizeof(double));
+
     result->multiplier = multiplier;
     result->base_units = base_units;
     TAILQ_INSERT_TAIL(values, result, next);
@@ -1145,6 +1178,7 @@ te_mi_logger_reset(te_mi_logger *logger)
     {
         while ((meas_value = TAILQ_FIRST(&meas->values)) != NULL)
         {
+            free(meas_value->vals);
             TAILQ_REMOVE(&meas->values, meas_value, next);
             free(meas_value);
         }
@@ -1349,6 +1383,71 @@ te_mi_logger_add_meas_units(te_mi_logger *logger, te_errno *retval,
         meas = te_mi_meas_impl_add(&logger->meas_q, type, name);
 
     te_mi_meas_value_add(&meas->values, aggr, val, multiplier, base_units);
+
+out:
+    te_mi_set_logger_error(logger, retval, rc);
+}
+
+void
+te_mi_logger_add_meas_series(te_mi_logger *logger, te_errno *retval,
+                             te_mi_meas_type type, const char *name,
+                             te_mi_meas_aggr aggr, size_t n_vals,
+                             const double *vals,
+                             te_mi_meas_multiplier multiplier,
+                             const char *base_units)
+{
+    te_mi_meas_impl *meas;
+    te_errno rc = 0;
+
+    if (logger == NULL)
+    {
+        ERROR("Failed to add measurement with invalid args");
+        rc = TE_EINVAL;
+        goto out;
+    }
+
+    if (aggr != TE_MI_MEAS_AGGR_SERIES)
+    {
+        ERROR("Logging measurement series supports TE_MI_MEAS_AGGR_SERIES aggregation only");
+        rc = TE_EINVAL;
+        goto out;
+    }
+
+    if (name != NULL && strcmp(name, TE_MI_GRAPH_AUTO_SEQNO) == 0)
+    {
+        ERROR("Name '%s' is reserved for MI graphs",
+              TE_MI_GRAPH_AUTO_SEQNO);
+        rc = TE_EINVAL;
+        goto out;
+    }
+
+    if (!te_mi_meas_type_valid(type))
+    {
+        ERROR("Invalid measurement type");
+        rc = TE_EINVAL;
+        goto out;
+    }
+
+    if (!te_mi_meas_aggr_is_specified(aggr))
+    {
+        ERROR("Invalid measurement aggregation");
+        rc = TE_EINVAL;
+        goto out;
+    }
+
+    if (!te_mi_meas_multiplier_valid(multiplier))
+    {
+        ERROR("Invalid measurement multiplier");
+        rc = TE_EINVAL;
+        goto out;
+    }
+
+    meas = te_mi_meas_impl_find(&logger->meas_q, type, name);
+    if (meas == NULL)
+        meas = te_mi_meas_impl_add(&logger->meas_q, type, name);
+
+    te_mi_meas_values_add(&meas->values, aggr, n_vals, vals, multiplier,
+                          base_units);
 
 out:
     te_mi_set_logger_error(logger, retval, rc);

--- a/lib/tools/te_mi_log.h
+++ b/lib/tools/te_mi_log.h
@@ -287,6 +287,8 @@ typedef struct te_mi_meas {
     double val;
     /** Scale of a measurement result */
     te_mi_meas_multiplier multiplier;
+    /** User-supplied base units */
+    const char *base_units;
 } te_mi_meas;
 
 /**
@@ -304,7 +306,14 @@ extern te_errno te_mi_logger_meas_create(const char *tool,
 #define TE_MI_MEAS(_type, _name, _aggr, _val, _multiplier)   \
     (te_mi_meas){ TE_MI_MEAS_ ## _type, (_name),        \
                   TE_MI_MEAS_AGGR_ ## _aggr, (_val),    \
-                  TE_MI_MEAS_MULTIPLIER_ ## _multiplier }
+                  TE_MI_MEAS_MULTIPLIER_ ## _multiplier, NULL }
+
+/** Convenience te_mi_meas constructor with base units */
+#define TE_MI_MEAS_UNITS(_type, _name, _aggr, _val, _multiplier, _base_units) \
+    (te_mi_meas){ TE_MI_MEAS_ ## _type, (_name),        \
+                  TE_MI_MEAS_AGGR_ ## _aggr, (_val),    \
+                  TE_MI_MEAS_MULTIPLIER_ ## _multiplier, \
+                  _base_units }
 
 /** Convenience te_mi_meas vector constructor for te_mi_log_meas() */
 #define TE_MI_MEAS_V(...) \
@@ -371,6 +380,28 @@ extern void te_mi_logger_add_meas(te_mi_logger *logger, te_errno *retval,
                                   te_mi_meas_type type, const char *name,
                                   te_mi_meas_aggr aggr, double val,
                                   te_mi_meas_multiplier multiplier);
+/**
+ * Variation of te_mi_logger_add_result() function that allows passing
+ * custom base units.
+ *
+ * @param           logger      MI logger
+ * @param           retval      Return code. If @c NULL is passed, @p logger
+ *                              is not @c NULL and error occures, error flag
+ *                              is stored in @p logger, which will fail the
+ *                              next te_mi_logger_flush().
+ * @param[in]       type        The type of the measurement result
+ * @param[in]       name        The name of the measurement result used to
+ *                              identify measurements in logs, may be @c NULL
+ * @param[in]       aggr        Aggregation type of the measurement
+ * @param[in]       val         Value of the measurement
+ * @param[in]       multiplier  Scale of the measurement value
+ * @param[in]       base_units  Base units of the measurement
+ */
+extern void te_mi_logger_add_meas_units(te_mi_logger *logger, te_errno *retval,
+                                        te_mi_meas_type type, const char *name,
+                                        te_mi_meas_aggr aggr, double val,
+                                        te_mi_meas_multiplier multiplier,
+                                        const char *base_units);
 
 /**
  * Variation of te_mi_logger_add_result() function that accepts

--- a/lib/tools/te_mi_log.h
+++ b/lib/tools/te_mi_log.h
@@ -186,6 +186,8 @@ typedef enum te_mi_meas_aggr {
     TE_MI_MEAS_AGGR_START = 0,
     /** Single measurement */
     TE_MI_MEAS_AGGR_SINGLE,
+    /** Series of values. */
+    TE_MI_MEAS_AGGR_SERIES,
     /** Measurement with the minimal value */
     TE_MI_MEAS_AGGR_MIN,
     /** Measurement with the maximum value */
@@ -289,6 +291,10 @@ typedef struct te_mi_meas {
     te_mi_meas_multiplier multiplier;
     /** User-supplied base units */
     const char *base_units;
+    /** Number of measurement values */
+    size_t n_vals;
+    /** Measurement values */
+    const double *vals;
 } te_mi_meas;
 
 /**
@@ -306,14 +312,14 @@ extern te_errno te_mi_logger_meas_create(const char *tool,
 #define TE_MI_MEAS(_type, _name, _aggr, _val, _multiplier)   \
     (te_mi_meas){ TE_MI_MEAS_ ## _type, (_name),        \
                   TE_MI_MEAS_AGGR_ ## _aggr, (_val),    \
-                  TE_MI_MEAS_MULTIPLIER_ ## _multiplier, NULL }
+                  TE_MI_MEAS_MULTIPLIER_ ## _multiplier, NULL, 0, NULL }
 
 /** Convenience te_mi_meas constructor with base units */
 #define TE_MI_MEAS_UNITS(_type, _name, _aggr, _val, _multiplier, _base_units) \
     (te_mi_meas){ TE_MI_MEAS_ ## _type, (_name),        \
                   TE_MI_MEAS_AGGR_ ## _aggr, (_val),    \
                   TE_MI_MEAS_MULTIPLIER_ ## _multiplier, \
-                  _base_units }
+                  _base_units, 0, NULL }
 
 /** Convenience te_mi_meas vector constructor for te_mi_log_meas() */
 #define TE_MI_MEAS_V(...) \
@@ -436,6 +442,31 @@ extern void te_mi_logger_add_meas_obj(te_mi_logger *logger, te_errno *retval,
  */
 extern void te_mi_logger_add_meas_vec(te_mi_logger *logger, te_errno *retval,
                                       const te_mi_meas *measurements);
+
+/**
+ * A memory-efficient variation of te_mi_logger_add_meas() function that allows
+ * passing a measurement describing multiple values that share their main
+ * properties like type and units.
+ *
+ * @param           logger      MI logger
+ * @param           retval      Return code. If @c NULL is passed, @p logger
+ *                              is not @c NULL and error occures, error flag
+ *                              is stored in @p logger, which will fail the
+ *                              next te_mi_logger_flush().
+ * @param[in]       type        The type of the measurement result
+ * @param[in]       name        The name of the measurement result used to
+ *                              identify measurements in logs, may be @c NULL
+ * @param[in]       aggr        Aggregation type of the measurement
+ * @param[in]       vals        Values of the measurement
+ * @param[in]       multiplier  Scale of the measurement value
+ * @param[in]       base_units  Base units of the measurement
+ */
+extern void te_mi_logger_add_meas_series(te_mi_logger *logger, te_errno *retval,
+                                        te_mi_meas_type type, const char *name,
+                                        te_mi_meas_aggr aggr, size_t n_vals,
+                                        const double *vals,
+                                        te_mi_meas_multiplier multiplier,
+                                        const char *base_units);
 
 /**
  * Add a measurement key to a MI logger. Measurement key is a key-value pair

--- a/tools/rgt/rgt-format/mi_msg.c
+++ b/tools/rgt/rgt-format/mi_msg.c
@@ -115,11 +115,14 @@ static void
 te_rgt_mi_meas_clean(te_rgt_mi_meas *meas)
 {
     size_t i;
+    size_t j;
 
     if (meas->params != NULL)
     {
         for (i = 0; i < meas->params_num; i++)
         {
+            for (j = 0; j < meas->params[i].values_num; j++)
+                free(meas->params[i].values[j].values);
             free(meas->params[i].values);
         }
 
@@ -610,7 +613,6 @@ te_rgt_parse_mi_meas_message(te_rgt_mi *mi)
             bool no_stats;
 
             te_rgt_mi_meas_param *param = &meas->params[param_id];
-            te_rgt_mi_meas_value value = TE_RGT_MI_MEAS_VALUE_INIT;
             size_t value_id = 0;
 
             result = json_array_get(results, i);
@@ -639,7 +641,9 @@ te_rgt_parse_mi_meas_message(te_rgt_mi *mi)
             for (j = 0; j < param->values_num; j++)
             {
                 json_t *entry;
+                json_t *values;
                 const char *aggr;
+                te_rgt_mi_meas_value value = TE_RGT_MI_MEAS_VALUE_INIT;
 
                 entry = json_array_get(entries, j);
                 if (entry == NULL || !json_is_object(entry))
@@ -650,9 +654,29 @@ te_rgt_parse_mi_meas_message(te_rgt_mi *mi)
                     continue;
 
                 value.defined = true;
-                if (json_object_get_number(entry, "value",
-                                           &value.value) == 0)
+
+                values = json_object_get(entry, "values");
+                if (json_is_array(values))
+                {
+                    size_t index;
+                    json_t *val;
+
+                    value.values_num = json_array_size(values);
+                    value.values = calloc(value.values_num, sizeof(double));
+
+                    json_array_foreach(values, index, val)
+                    {
+                        if (json_is_number(val))
+                            value.values[index] = json_number_value(val);
+                    }
+
                     value.specified = true;
+                }
+                else if (json_object_get_number(entry, "value",
+                                           &value.value) == 0)
+                {
+                    value.specified = true;
+                }
 
                 value.multiplier = json_object_get_string(entry,
                                                           "multiplier");
@@ -694,7 +718,7 @@ te_rgt_parse_mi_meas_message(te_rgt_mi *mi)
                 }
                 else
                 {
-                    if (strcmp(aggr, "single") == 0)
+                    if (strcmp(aggr, "single") == 0 || strcmp(aggr, "series") == 0)
                     {
                         param->values[value_id] = value;
                         value_id++;

--- a/tools/rgt/rgt-format/mi_msg.h
+++ b/tools/rgt/rgt-format/mi_msg.h
@@ -38,12 +38,14 @@ typedef struct te_rgt_mi_meas_value {
     bool specified;          /**< If @c true, the numeric value was
                                      specified */
     double value;               /**< Value of "value" field */
+    size_t values_num;          /**< Length of "values" array" */
+    double *values;             /**< Values of "values" array */
     const char *multiplier;     /**< Value of "multiplier" field */
     const char *base_units;     /**< Value of "base_units" field */
 } te_rgt_mi_meas_value;
 
 /** Initializer for te_rgt_mi_meas_value structure */
-#define TE_RGT_MI_MEAS_VALUE_INIT { false, false, 0, NULL, NULL }
+#define TE_RGT_MI_MEAS_VALUE_INIT { false, false, 0, 0, NULL, NULL, NULL }
 
 /** Description of measured parameter */
 typedef struct te_rgt_mi_meas_param {

--- a/tools/rgt/rgt-format/xml2html-multi/xml2html-multi.c
+++ b/tools/rgt/rgt-format/xml2html-multi/xml2html-multi.c
@@ -853,7 +853,10 @@ print_mi_meas_param_vals_array(FILE *fd, te_rgt_mi_meas_param *param)
 
                 for (i = 0; i < value->values_num; i++)
                 {
-                    fprintf(fd, "%f * %.9f", value->values[i], multiplier_value);
+                    if (multiplier_value == 1.0)
+                        fprintf(fd, "%f", value->values[i]);
+                    else
+                        fprintf(fd, "%f * %.9f", value->values[i], multiplier_value);
 
                     if (i != value->values_num - 1)
                         fprintf(fd, ", ");
@@ -861,7 +864,10 @@ print_mi_meas_param_vals_array(FILE *fd, te_rgt_mi_meas_param *param)
             }
             else
             {
-                fprintf(fd, "%f * %.9f", value->value, multiplier_value);
+                if (multiplier_value == 1.0)
+                    fprintf(fd, "%f", value->value);
+                else
+                    fprintf(fd, "%f * %.9f", value->value, multiplier_value);
             }
             first_val = false;
         }

--- a/tools/rgt/rgt-format/xml2html-multi/xml2html-multi.c
+++ b/tools/rgt/rgt-format/xml2html-multi/xml2html-multi.c
@@ -738,6 +738,38 @@ RGT_DEF_FUNC(proc_log_msg_start)
 }
 
 /**
+ * Print a single measurement value.
+ *
+ * @param fd            File where to print.
+ * @param value         Value to print.
+ * @param multiplier    Value multiplier.
+ * @param base_units    Value base units.
+ * @param prefix        Prefix string (may be @c NULL).
+ */
+static void
+print_mi_meas_value_impl(FILE *fd, te_optional_double_t value,
+                         const char *multiplier, const char *base_units,
+                         const char *prefix)
+{
+    fprintf(fd, "<li>");
+    if (prefix != NULL)
+        fprintf(fd, "%s: ", prefix);
+
+    if (value.defined)
+        fprintf(fd, "%f", value.value);
+    else
+        fprintf(fd, "[failed to obtain]");
+
+    if (multiplier != NULL && *multiplier != '\0' &&
+        strcmp(multiplier, "1") != 0)
+        fprintf(fd, " * %s", multiplier);
+    if (base_units != NULL && *base_units != '\0')
+        fprintf(fd, " %s", base_units);
+
+    fprintf(fd, "</li>\n");
+}
+
+/**
  * Print a measurement value.
  *
  * @param fd      File where to print.
@@ -750,22 +782,28 @@ print_mi_meas_value(FILE *fd, te_rgt_mi_meas_value *value, const char *prefix)
     if (!(value->defined))
         return;
 
-    fprintf(fd, "<li>");
-    if (prefix != NULL)
-        fprintf(fd, "%s: ", prefix);
+    if (!value->specified)
+        print_mi_meas_value_impl(fd, TE_OPTIONAL_DOUBLE_UNDEF, value->multiplier,
+                                 value->base_units, prefix);
 
-    if (value->specified)
-        fprintf(fd, "%f", value->value);
+
+    if (value->values_num > 0)
+    {
+        size_t i;
+
+        for (i = 0; i < value->values_num; i++)
+        {
+            print_mi_meas_value_impl(fd,
+                                     TE_OPTIONAL_DOUBLE_VAL(value->values[i]),
+                                     value->multiplier, value->base_units,
+                                     prefix);
+        }
+    }
     else
-        fprintf(fd, "[failed to obtain]");
-
-    if (value->multiplier != NULL && *(value->multiplier) != '\0' &&
-        strcmp(value->multiplier, "1") != 0)
-        fprintf(fd, " * %s", value->multiplier);
-    if (value->base_units != NULL && *(value->base_units) != '\0')
-        fprintf(fd, " %s", value->base_units);
-
-    fprintf(fd, "</li>\n");
+    {
+        print_mi_meas_value_impl(fd, TE_OPTIONAL_DOUBLE_VAL(value->value),
+                                 value->multiplier, value->base_units, prefix);
+    }
 }
 
 /**
@@ -809,7 +847,22 @@ print_mi_meas_param_vals_array(FILE *fd, te_rgt_mi_meas_param *param)
                 }
             }
 
-            fprintf(fd, "%f * %.9f", value->value, multiplier_value);
+            if (value->values_num > 0)
+            {
+                size_t i;
+
+                for (i = 0; i < value->values_num; i++)
+                {
+                    fprintf(fd, "%f * %.9f", value->values[i], multiplier_value);
+
+                    if (i != value->values_num - 1)
+                        fprintf(fd, ", ");
+                }
+            }
+            else
+            {
+                fprintf(fd, "%f * %.9f", value->value, multiplier_value);
+            }
             first_val = false;
         }
     }
@@ -1006,6 +1059,8 @@ log_mi_measurement(FILE *fd, te_rgt_mi *mi, unsigned int linum)
 
         if (param->values_num > 0)
         {
+            size_t total_values = 0;
+
             if (param->in_graph)
             {
                 fprintf(fd, "<script>var param_%u_%zu = [",
@@ -1018,23 +1073,31 @@ log_mi_measurement(FILE *fd, te_rgt_mi *mi, unsigned int linum)
 
             FPRINTF_HEADER(3, fd, "Values:");
 
+            for (j = 0; j < param->values_num; j++)
+            {
+                if (param->values[j].values_num > 0)
+                    total_values += param->values[j].values_num;
+                else
+                    total_values += 1;
+            }
+
             fprintf(fd, "<span class=\"%s_link\" "
                     "onclick=\"show_hide_list(this, "
                     "'meas_param_list_%u_%zu', 'Hide %zu values', "
                     "'Show %zu values');\">%s %zu values"
                     "</span>\n",
-                    (param->values_num > max_showed_vals ?
+                    (total_values > max_showed_vals ?
                         "show" : "hide"),
-                    linum, i, param->values_num, param->values_num,
-                    (param->values_num > max_showed_vals ?
+                    linum, i, total_values, total_values,
+                    (total_values > max_showed_vals ?
                         "Show" : "Hide"),
-                    param->values_num);
+                    total_values);
 
             fprintf(fd, "<ul id=\"meas_param_list_%u_%zu\" "
                     "style=\"display:%s; list-style-type:none;\">\n",
                     linum, i,
-                    (param->values_num > max_showed_vals ?
-                                            "none" : "block"));
+                    (total_values > max_showed_vals ?
+                                       "none" : "block"));
             for (j = 0; j < param->values_num; j++)
             {
                 print_mi_meas_value(fd, &param->values[j], NULL);

--- a/tools/rgt/rgt-format/xml2text/xml2text.c
+++ b/tools/rgt/rgt-format/xml2text/xml2text.c
@@ -582,27 +582,60 @@ RGT_DEF_FUNC(proc_log_msg_start)
  * @param prefix  Prefix string (may be @c NULL).
  */
 static void
-print_mi_meas_value(gen_ctx_user_t *ctx, te_rgt_mi_meas_value *value,
-                    const char *prefix)
+print_mi_meas_value_impl(gen_ctx_user_t *ctx, te_optional_double_t value,
+                    const char *multiplier, const char *base_units, const char *prefix)
 {
-    if (!(value->defined))
-        return;
-
     if (prefix != NULL)
         fprintf_log(ctx, "%15s: ", prefix);
 
-    if (value->specified)
-        fprintf_log(ctx, "%f", value->value);
+    if (value.defined)
+        fprintf_log(ctx, "%f", value.value);
     else
         fprintf_log(ctx, "[failed to obtain]");
 
-    if (value->multiplier != NULL && *(value->multiplier) != '\0' &&
-        strcmp(value->multiplier, "1") != 0)
-        fprintf_log(ctx, " * %s", value->multiplier);
-    if (value->base_units != NULL && *(value->base_units) != '\0')
-        fprintf_log(ctx, " %s", value->base_units);
+    if (multiplier != NULL && *multiplier != '\0' &&
+        strcmp(multiplier, "1") != 0)
+        fprintf_log(ctx, " * %s", multiplier);
+    if (base_units != NULL && *base_units != '\0')
+        fprintf_log(ctx, " %s", base_units);
 
     fprintf_log(ctx, "\n");
+}
+
+/**
+ * Print a measurement value.
+ *
+ * @param ctx     Logging context.
+ * @param value   Value to print.
+ * @param prefix  Prefix string (may be @c NULL).
+ */
+static void
+print_mi_meas_value(gen_ctx_user_t *ctx, te_rgt_mi_meas_value *value,
+                    const char *prefix)
+{
+    if (!value->defined)
+        return;
+
+    if (!value->specified)
+        print_mi_meas_value_impl(ctx, TE_OPTIONAL_DOUBLE_UNDEF, value->multiplier,
+                                 value->base_units, prefix);
+
+
+    if (value->values_num > 0)
+    {
+        size_t i;
+
+        for (i = 0; i < value->values_num; i++)
+            print_mi_meas_value_impl(ctx,
+                                     TE_OPTIONAL_DOUBLE_VAL(value->values[i]),
+                                     value->multiplier, value->base_units,
+                                     prefix);
+    }
+    else
+    {
+        print_mi_meas_value_impl(ctx, TE_OPTIONAL_DOUBLE_VAL(value->value),
+                                 value->multiplier, value->base_units, prefix);
+    }
 }
 
 /**


### PR DESCRIPTION
MI measurements are logged as separate JSON objects, each duplicating the measurement aggregation type, units and multiplier. This makes each measurement take much more space than a single floating point value.

Introduce a new "series" aggregation type that allows tests to log a series of measurements that share their properties in one JSON object.

For example, the following sequence

```
{"aggr":"single","value":0.00202225,"base_units":"seconds","multiplier":"1"}
{"aggr":"single","value":0.00303048,"base_units":"seconds","multiplier":"1"}
{"aggr":"single","value":0.00403947, "base_units":"seconds","multiplier":"1"}
```

turns into one object:

```
{"aggr":"series","values":[0.00202225, 0.00303048, 0.00403947],"base_units":"seconds","multiplier":"1"}
```

Our test suite provides test iterations that can log 30000 such measurements, see below for the final log sizes before these patches, after compacting MI log messages, and after removing 1.0 multipliers from HTML logs:

```
~/run-old$ du -sh tmp_raw_log log.txt html
854M    tmp_raw_log
395M    log.txt
1.3G    html

~/run-compact$ du -sh tmp_raw_log log.txt html
292M    tmp_raw_log
398M    log.txt
768M    html

run-compact-html$ du -sh tmp_raw_log log.txt html
287M    tmp_raw_log
392M    log.txt
352M    html
```