### PR TITLE
builder: fix command strings for local test agents

### DIFF
--- a/engine/builder/te_ta_ssh_helper
+++ b/engine/builder/te_ta_ssh_helper
@@ -478,5 +478,9 @@ function te_ta_process_cmd() {
 
     te_ta_ssh_args "${ta}" && ssh_args=("${TE_SSH_ARGS[@]}")
 
-    ${ssh_args:+ssh "${ssh_args[@]}"} "/bin/bash -c 'set -e; cd /tmp; $cmd'"
+    if [[ -z ${ssh_args[@]} ]]; then
+        /bin/bash -c "set -e; cd /tmp; $cmd"
+    else
+        ssh "${ssh_args[@]}" "/bin/bash -c 'set -e; cd /tmp; $cmd'"
+    fi
 }


### PR DESCRIPTION
If we do not need to use SSH to reach the test agent's shell, we must not wrap the command in quotation marks, because then the entire command with all its arguments is treated as a single executable entity without any arguments.

Testing done: a test suite that uses `te_ta_process_cmd` to gather TRC tags now starts correctly when local test agents are used