### PR TITLE
Make agent routes optionally volatile 

### DIFF
--- a/doc/cm/cm_base.yml
+++ b/doc/cm/cm_base.yml
@@ -1525,6 +1525,7 @@
     - oid: "/agent/route"
       access: read_create
       type: address
+      volatile: ${TE_VOLATILE_ROUTES:-false}
       depends:
         - oid: "/agent/interface"
         - oid: "/agent/interface/status"

--- a/engine/configurator/conf_backup.c
+++ b/engine/configurator/conf_backup.c
@@ -9,6 +9,8 @@
 
 #include "conf_defs.h"
 #include "te_alloc.h"
+#define TE_EXPAND_XML 1
+#include "te_expand.h"
 
 /**
  * Parses all object dependencies in the configuration file.
@@ -184,7 +186,8 @@ register_objects(xmlNodePtr *node, bool reg)
             xmlFree(attr);
         }
 
-        if ((attr = xmlGetProp(cur, (const xmlChar *)"volatile")) != NULL)
+        if ((attr = (xmlChar *)xmlGetProp_exp(cur, (const xmlChar *)"volatile"))
+                != NULL)
         {
             if (strcmp((char *)attr, "true") == 0)
                 msg->vol = true;

--- a/engine/configurator/conf_dh.c
+++ b/engine/configurator/conf_dh.c
@@ -693,7 +693,7 @@ cfg_dh_process_file(xmlNodePtr node, te_kvpair_h *expand_vars,
                     attr = NULL;
                 }
 
-                attr = (char *)xmlGetProp(tmp, (const xmlChar *)"volatile");
+                attr = xmlGetProp_exp(tmp, (const xmlChar *)"volatile");
                 if (attr != NULL)
                 {
                     if (strcmp(attr, "true") == 0)


### PR DESCRIPTION
This may be required on some networks where routes are periodically updated. One such example is AWS, where routes may occasionally change their metric value. These changes may break testing when Configurator tries to replace the new route with whatever route was in place at the start of a test run.

Testing done: test runs on AWS become stable when `TE_VOLATILE_ROUTES` is set to `true`